### PR TITLE
cli tool for template validation

### DIFF
--- a/bin/validate-template.js
+++ b/bin/validate-template.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+var cloudfriend = require('..');
+var templatePath = process.argv[2];
+
+cloudfriend.validate(templatePath, 'us-east-1')
+  .then(function() {
+    console.log('✔ valid');
+  }).catch(function(err) {
+    console.log('✘ invalid: %s', err.message);
+  });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build-ci-template": "bin/build-template.js cloudformation/ci.template.js > cloudformation/ci.template.json"
   },
   "bin": {
-    "build-template": "bin/build-template.js"
+    "build-template": "bin/build-template.js",
+    "validate-template": "bin/validate-template.js"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -36,3 +36,28 @@ method | description
 build(templatePath) | Builds a template defined by a static JavaScript export, a synchronous or an asynchronous function
 validate(templatePath) | Uses the `cloudformation:ValidateTemplate` API call to perform rudimentary template validation
 merge(template, template, ...) | Merges templates together. Throws errors if logical names are reused
+
+## CLI tools
+
+By installing cloudfriend globally, it can provide you with simple CLI tools for building and validating CloudFormation templates.
+
+```
+# either...
+$ git clone https://github.com/mapbox/cloudfriend && cd cloudfriend && npm link
+# ... or ...
+$ npm install -g cloudfriend
+```
+
+Then, to build a template:
+
+```
+# Prints the template as JSON to stdout
+$ build-template path/to/template.js
+```
+
+Or, to validate a template:
+
+```
+# Make sure that your shell is configured to make AWS requests
+$ validate-template path/to/template.js
+```


### PR DESCRIPTION
Adds a small wrapper on `cloudfriend.validate()` for CLI usage.