### PR TITLE
Better builder

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var path = require('path');
 
 /**
@@ -8,20 +9,34 @@ var path = require('path');
  * @memberof cloudfriend
  * @name build
  * @param {string} templatePath - the filesystem path to a JSON or JS template.
+ * @param {object} [templateOptions] - an object to pass to a JS template function
+ * as the first argument.
  * @returns {promise} a promise that will resolve with the template's body.
  */
-module.exports = (templatePath) => {
-  var template = require(path.resolve(templatePath));
+module.exports = (templatePath, templateOptions) => {
+  templatePath = path.resolve(templatePath);
+  var template;
 
+  if (!/\.js$/.test(templatePath)) {
+    template = fs.readFileSync(templatePath);
+    try { template = JSON.parse(template); }
+    catch (err) { return Promise.reject(err); }
+    return Promise.resolve(template);
+  }
+
+  template = require(templatePath);
   return new Promise((resolve, reject) => {
-    if (typeof template !== 'function')
-      return resolve(template);
+    if (typeof template !== 'function') return resolve(template);
 
-    var resolved = template((err, data) => {
+    function finished(err, data) {
       if (err) return reject(err);
       resolve(data);
-    });
+    }
 
+    var args = [finished];
+    if (templateOptions) args.unshift(templateOptions);
+
+    var resolved = template.apply(null, args);
     if (resolved) return resolve(resolved);
   });
 };

--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,9 @@ stackName | [AWS::StackName](http://docs.aws.amazon.com/AWSCloudFormation/latest
 
 method | description
 --- | ---
-build(templatePath) | Builds a template defined by a static JavaScript export, a synchronous or an asynchronous function
+build(templatePath, opts) | Builds a template defined by a static JavaScript export, a synchronous or an asynchronous function.
 validate(templatePath) | Uses the `cloudformation:ValidateTemplate` API call to perform rudimentary template validation
-merge(template, template, ...) | Merges templates together. Throws errors if logical names are reused
+merge(...template) | Merges templates together. Throws errors if logical names are reused
 
 ## CLI tools
 

--- a/test/fixtures/async-args.js
+++ b/test/fixtures/async-args.js
@@ -1,0 +1,3 @@
+module.exports = function(options, callback) {
+  setImmediate(callback, null, options);
+};

--- a/test/fixtures/sync-args.js
+++ b/test/fixtures/sync-args.js
@@ -1,0 +1,3 @@
+module.exports = function(options) {
+  return options;
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,7 +40,7 @@ test('pseudo', (assert) => {
 });
 
 test('build', (assert) => {
-  assert.plan(5);
+  assert.plan(8);
 
   cloudfriend.build(path.join(fixtures, 'static.json'))
     .then(function(template) {
@@ -57,10 +57,24 @@ test('build', (assert) => {
     })
     .then(function(template) {
       assert.deepEqual(template, expectedTemplate, 'async.js (success)');
-      return cloudfriend.build(path.join(fixtures, 'async-error.js'));
+      return cloudfriend.build(path.join(fixtures, 'async-error.js'))
+        .catch(function(err) {
+          assert.ok(err, 'async.js (error)');
+        });
     })
-    .catch(function(err) {
-      assert.ok(err, 'async.js (error)');
+    .then(function() {
+      return cloudfriend.build(path.join(fixtures, 'sync-args.js'), { some: 'options' });
+    })
+    .then(function(template) {
+      assert.deepEqual(template, { some: 'options', }, 'passes args (sync)');
+      return cloudfriend.build(path.join(fixtures, 'async-args.js'), { some: 'options' });
+    })
+    .then(function(template) {
+      assert.deepEqual(template, { some: 'options', }, 'passes args (async)');
+      return cloudfriend.build(path.join(fixtures, 'malformed.json'))
+        .catch(function(err) {
+          assert.ok(err, 'malformed JSON (error)');
+        });
     });
 });
 


### PR DESCRIPTION
Fixes `cloudfriend.build` by:

- being able to parse straight JSON templates even without a `.json` extension
- optionally providing and `options` argument to `.js` templates that export a function.