### PR TITLE
exit 1 for invalid template in bin/validate

### DIFF
--- a/bin/validate-template.js
+++ b/bin/validate-template.js
@@ -10,4 +10,5 @@ cloudfriend.validate(templatePath, 'us-east-1')
     console.log('✔ valid');
   }).catch(function(err) {
     console.log('✘ invalid: %s', err.message);
+    process.exit(1);
   });


### PR DESCRIPTION
I want to use cloudfriend's template validator in my `package.json` like:
```json
"pretest": "validate-template my-template.js"
```

I've added an `exit 1` so that tests fail if this validation fails, otherwise they'll just log the failure and continue on happily.

@rclark what do you think? Is cloudfriend the right spot for this, or is there a better way to achieve this?
