### PR TITLE
Improved .merge()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## v1.5.0
+
+- `.merge()` now allows name reuse across template properties, e.g. can have a Resource and an Output with the same name.
+- `.merge()` now allows name overlaps if the provided objects are identical.
+
 ## v1.4.0
 
 - `validate-template` now exits 1 if the template is invalid.

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,3 +1,4 @@
+var assert = require('assert');
 
 /**
  * Merges two or more templates together into one.
@@ -23,43 +24,74 @@ module.exports = function() {
     Outputs: {}
   };
 
-  var names = new Set();
+  var names = {
+    Metadata: new Set(),
+    Parameters: new Set(),
+    Mappings: new Set(),
+    Conditions: new Set(),
+    Resources: new Set(),
+    Outputs: new Set()
+  };
 
   for (var arg of arguments) {
     if (arg.Metadata) Object.keys(arg.Metadata).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Metadata.has(key)) {
+        try { assert.deepEqual(template.Metadata[key], arg.Metadata[key]); }
+        catch (err) { throw new Error('Metadata name used more than once: ' + key); }
+      }
+
       template.Metadata[key] = arg.Metadata[key];
-      names.add(key);
+      names.Metadata.add(key);
     });
 
     if (arg.Parameters) Object.keys(arg.Parameters).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Parameters.has(key)) {
+        try { assert.deepEqual(template.Parameters[key], arg.Parameters[key]); }
+        catch (err) { throw new Error('Parameters name used more than once: ' + key); }
+      }
+
       template.Parameters[key] = arg.Parameters[key];
-      names.add(key);
+      names.Parameters.add(key);
     });
 
     if (arg.Mappings) Object.keys(arg.Mappings).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Mappings.has(key)) {
+        try { assert.deepEqual(template.Mappings[key], arg.Mappings[key]); }
+        catch (err) { throw new Error('Mappings name used more than once: ' + key); }
+      }
+
       template.Mappings[key] = arg.Mappings[key];
-      names.add(key);
+      names.Mappings.add(key);
     });
 
     if (arg.Conditions) Object.keys(arg.Conditions).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Conditions.has(key)) {
+        try { assert.deepEqual(template.Conditions[key], arg.Conditions[key]); }
+        catch (err) { throw new Error('Conditions name used more than once: ' + key); }
+      }
+
       template.Conditions[key] = arg.Conditions[key];
-      names.add(key);
+      names.Conditions.add(key);
     });
 
     if (arg.Resources) Object.keys(arg.Resources).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Resources.has(key)) {
+        try { assert.deepEqual(template.Resources[key], arg.Resources[key]); }
+        catch (err) { throw new Error('Resources name used more than once: ' + key); }
+      }
+
       template.Resources[key] = arg.Resources[key];
-      names.add(key);
+      names.Resources.add(key);
     });
 
     if (arg.Outputs) Object.keys(arg.Outputs).forEach((key) => {
-      if (names.has(key)) throw new Error('LogicalName used more than once: ' + key);
+      if (names.Outputs.has(key)) {
+        try { assert.deepEqual(template.Outputs[key], arg.Outputs[key]); }
+        catch (err) { throw new Error('Outputs name used more than once: ' + key); }
+      }
+
       template.Outputs[key] = arg.Outputs[key];
-      names.add(key);
+      names.Outputs.add(key);
     });
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -146,39 +146,69 @@ test('merge', (assert) => {
   }, 'merge without overlap');
 
   assert.throws(function() {
+    b = { Metadata: { Instances: { Description: 'Information about the instances different' } } };
+    cloudfriend.merge(a, b);
+  }, /Metadata name used more than once: Instances/, 'throws on .Metadata overlap');
+
+  assert.doesNotThrow(function() {
     b = { Metadata: { Instances: { Description: 'Information about the instances' } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: Instances/, 'throws on .Metadata overlap');
+  }, 'allows identical .Metadata overlap');
 
   assert.throws(function() {
+    b = { Parameters: { InstanceCount: { Type: 'Number', Description: 'Different' } } };
+    cloudfriend.merge(a, b);
+  }, /Parameters name used more than once: InstanceCount/, 'throws on .Parameters overlap');
+
+  assert.doesNotThrow(function() {
     b = { Parameters: { InstanceCount: { Type: 'Number' } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: InstanceCount/, 'throws on .Parameters overlap');
+  }, 'allows identical .Parameters overlap');
 
   assert.throws(function() {
+    b = { Mappings: { Region: { 'us-east-1': { AMI: 'ami-123456' }, 'us-east-4': { AMI: 'ami-123456' } } } };
+    cloudfriend.merge(a, b);
+  }, /Mappings name used more than once: Region/, 'throws on .Mappings overlap');
+
+  assert.doesNotThrow(function() {
     b = { Mappings: { Region: { 'us-east-1': { AMI: 'ami-123456' } } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: Region/, 'throws on .Mappings overlap');
+  }, 'allows identical .Mappings overlap');
 
   assert.throws(function() {
+    b = { Conditions: { WouldYouLikeBaconWithThat: cloudfriend.equals(cloudfriend.ref('InstanceCount'), 998) } };
+    cloudfriend.merge(a, b);
+  }, /Conditions name used more than once: WouldYouLikeBaconWithThat/, 'throws on .Conditions overlap');
+
+  assert.doesNotThrow(function() {
     b = { Conditions: { WouldYouLikeBaconWithThat: cloudfriend.equals(cloudfriend.ref('InstanceCount'), 999) } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: WouldYouLikeBaconWithThat/, 'throws on .Conditions overlap');
+  }, 'allows identical .Conditions overlap');
 
   assert.throws(function() {
+    b = { Resources: { Instance: { Type: 'AWS::EC2::Instance', Properties: { ImageId: cloudfriend.findInMap('Region', cloudfriend.region, 'AMIz') } } } };
+    cloudfriend.merge(a, b);
+  }, /Resources name used more than once: Instance/, 'throws on .Resources overlap');
+
+  assert.doesNotThrow(function() {
     b = { Resources: { Instance: { Type: 'AWS::EC2::Instance', Properties: { ImageId: cloudfriend.findInMap('Region', cloudfriend.region, 'AMI') } } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: Instance/, 'throws on .Resources overlap');
+  }, 'allows identical .Resources overlap');
 
   assert.throws(function() {
+    b = { Outputs: { Breakfast: { Condition: 'WouldYouLikeBaconWithThat', Value: cloudfriend.ref('Instancez') } } };
+    cloudfriend.merge(a, b);
+  }, /Outputs name used more than once: Breakfast/, 'throws on .Outputs overlap');
+
+  assert.doesNotThrow(function() {
     b = { Outputs: { Breakfast: { Condition: 'WouldYouLikeBaconWithThat', Value: cloudfriend.ref('Instance') } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: Breakfast/, 'throws on .Outputs overlap');
+  }, 'allows identical .Outputs overlap');
 
-  assert.throws(function() {
+  assert.doesNotThrow(function() {
     b = { Mappings: { Instance: { 'us-east-1': { AMI: 'ami-123456' } } } };
     cloudfriend.merge(a, b);
-  }, /LogicalName used more than once: Instance/, 'throws on cross-property name overlap');
+  }, 'does not throw on cross-property name overlap');
 
   assert.end();
 });


### PR DESCRIPTION
- Can use the same names across template properties, e.g. can have a Resource and Output with the same name
- Will not throw on name overlap if the objects are identical

cc @yhahn 