### PR TITLE
Add node 6 as supported engine version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - '4'
+- '6'
 env:
   global:
   - secure: ucYs7Z82X7hsIq70GF3dgxmXI+VzBzM22B+jwGcJRQvp1R12fRv/P8/Eb/ScvDCeU9cJvP/FJ8GeGC6kPFHDjCZLyCxFG/SY/O550lE+hkTkQjHG933p3F2a0jCmhlMC2kTI7Dw4yk9dK0tgpnzBmswbgtT/QyvcImcxzBC0hcr9KJ3JCvSpQmi+TFdaDRmqs6H5Qy2owfiD6Ei0y6s3JEygYDHqWTbsrovhUwRvlFh/NgWOZ1lDu0FV71iPE+3LGrkSp+xyEAVQN/1ar/hqTufhSvcxD9Uf2kGUwqg4U2n+k46jd6h1rTDXyh31J62k2AJN0T6p6N5EGBKS/zzvuuhQN/yZdieMdxQpAho8i5TZyXdVp+RHPQxoTNnHL+O6obad13Q+o2iCr/1zaYefjG+23/wGCxdBtkjukGrD+6CwZ8gSwUxqhBUh9Q8oDI92jxd+jWp2VEcs7sXravaHhBWG2oNrb8tksOOElP2iD2iRkUdnvrAORzKWsxi7d3FhQE2TtvvD+icwpMQ6oHZS0PFKC0YzlUp3mfhtOl56UJsYYgEuamloUwsblO+kr5P60ZMevuyx5jNEE05bKi2kJ2kj02P0MD9cXjrWqNvcTBX6CYs/X3XSruBJPQNxbrp+rrsZWw2lFRXGg9+m1kS691TPhgRbMyOWL89zV0PqrGY=

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {
-    "node": "^4.4.7"
+    "node": ">=4.4.7"
   },
   "scripts": {
     "pretest": "eslint index.js test lib bin cloudformation",


### PR DESCRIPTION
Currently Cloudfriend's package.json specifies the following:

```
  "engines": {
    "node": "^4.4.7"
  },
```

Under this rule, Node 6 (which is due to become the current LTS Node version [on 10/18/2016](https://github.com/nodejs/LTS/blob/master/README.md)) is not a supported engine.

This becomes an issue when trying to install Cloudfriend on Node 6 using npm with the [`engine-strict` config parameter](https://docs.npmjs.com/misc/config#engine-strict), or with a node package manager like [Yarn](https://yarnpkg.com) that checks engine versions more strictly than NPM does by default.

**npm with engine-strict example**

```
$> npm config set engine-strict true && npm install ./
cloudfriend@1.6.0 /Users/bjacobel/code/cloudfriend
└── d@0.1.1  extraneous

npm ERR! Darwin 15.5.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install" "./"
npm ERR! node v6.7.0
npm ERR! npm  v3.10.8
npm ERR! code ENOTSUP

npm ERR! notsup Unsupported engine for cloudfriend@1.6.0: wanted: {"node":"^4.4.7"} (current: {"node":"6.7.0","npm":"3.10.8"})
npm ERR! notsup Not compatible with your version of node/npm: cloudfriend@1.6.0
npm ERR! notsup Not compatible with your version of node/npm: cloudfriend@1.6.0
npm ERR! notsup Required: {"node":"^4.4.7"}
npm ERR! notsup Actual:   {"npm":"3.10.8","node":"6.7.0"}

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/bjacobel/code/cloudfriend/npm-debug.log
```

**yarn example**

```
$> yarn install
yarn install v0.15.1
info No lockfile found.
[1/4] 🔍  Resolving packages...
...
[2/4] 🚚  Fetching packages...
error cloudfriend@1.6.0: The engine "node" is incompatible with this module. Expected version "^4.4.7".
error Found incompatible module
```

This PR adds changes the package.json engine setting to accept any Node version greater than 4.4.7, and adds Node 6 to the Travis build matrix.
