### PR TITLE
Allow for split on objects and strings

### DIFF
--- a/lib/intrinsic.js
+++ b/lib/intrinsic.js
@@ -199,9 +199,9 @@ intrinsic.importValue = (sharedValue) => {
  * @memberof cloudfriend
  * @name split
  * @param {string} delimiter - The delimiter you would like to split the string on
- * @param {string} string - The string you would like to split
+ * @param {object} object - The item you would like to split -- can be a string or an object
  * @returns The attribute value.
  */
-intrinsic.split = (delimiter, string) => {
-  return { 'Fn::Split': [delimiter, string.toString()] };
+intrinsic.split = (delimiter, object) => {
+  return { 'Fn::Split': [delimiter, object] };
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,7 @@ test('intrinsic functions', (assert) => {
   assert.deepEqual(cloudfriend.select(1, ['abra', 'cadabra']), { 'Fn::Select': ['1', ['abra', 'cadabra']] }, '');
   assert.deepEqual(cloudfriend.ref('something'), { Ref: 'something' }, 'ref');
   assert.deepEqual(cloudfriend.split(',', 'a,b,c,d'), { 'Fn::Split': [',', 'a,b,c,d'] }, 'split');
+  assert.deepEqual(cloudfriend.split(',', cloudfriend.ref('Id')), { 'Fn::Split': [',', { Ref: 'Id' }] }, 'split');
   assert.deepEqual(cloudfriend.userData(['#!/usr/bin/env bash', 'set -e']), { 'Fn::Base64': { 'Fn::Join': ['\n', ['#!/usr/bin/env bash', 'set -e']] } }, 'userData');
   assert.deepEqual(cloudfriend.sub('my ${thing}'), { 'Fn::Sub': 'my ${thing}' }, 'sub without variables');
   assert.deepEqual(cloudfriend.sub('my ${thing}', { thing: 'stuff' }), { 'Fn::Sub': ['my ${thing}', { thing: 'stuff' }] }, 'sub with variables');


### PR DESCRIPTION
gettin' rid of ol .toString()

refs https://github.com/mapbox/cloudfriend/issues/17

cc @rclark 