### PR TITLE
Update to IAM Group return value

### DIFF
--- a/lib/dereferencer/return-values.js
+++ b/lib/dereferencer/return-values.js
@@ -117,7 +117,7 @@ class ReturnValues {
 
   'AWS::IAM::Group'(resource) {
     return {
-      Ref: `${this.stackName}-${resource.Name}`
+      Ref: `${resource.Name}`
     };
   }
 


### PR DESCRIPTION
Made a mistake in setting the `Ref` return value, this updates it to just `${resource.Name}`.

/cc @rclark 