### PR TITLE
Loosen engines.node to 4 || 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {
-    "node": ">=4.4.7"
+    "node": "4 || 6"
   },
   "scripts": {
     "pretest": "eslint index.js test lib bin cloudformation",


### PR DESCRIPTION
This allows upstream modules to use other versions of the major 4 and 6 nodejs engines, rather than locking to a specific version.