### PR TITLE
Enable validate-template to optionally validate stdin

### DIFF
--- a/bin/validate-template.js
+++ b/bin/validate-template.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 var cloudfriend = require('..');
-var templatePath = process.argv[2];
+var templatePath = process.argv[2] || '-'; // if no templatePath is given, try stdin
 
 cloudfriend.validate(templatePath, 'us-east-1')
   .then(function() {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,6 @@
 var AWS = require('aws-sdk');
 var build = require('./build');
+var getStdin = require('get-stdin');
 
 /**
  * Validates a template.
@@ -14,8 +15,11 @@ var build = require('./build');
  */
 module.exports = (templatePath, region) => {
   var cfn = new AWS.CloudFormation({ region: region || 'us-east-1' });
-
-  return build(templatePath).then(function(template) {
+  return (
+    templatePath === '-' ? 
+      getStdin().then(JSON.parse) :
+      build(templatePath)
+  ).then(function(template) {
     return cfn.validateTemplate({ TemplateBody: JSON.stringify(template) }).promise();
   });
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "tape": "^4.6.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.4.11"
+    "aws-sdk": "^2.4.11",
+    "get-stdin": "^6.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ domainSuffix | [AWS::DomainSuffix](https://docs.aws.amazon.com/AWSCloudFormation
 method | description
 --- | ---
 build(file, opts) | Builds a template defined by a static JavaScript export, a synchronous or an asynchronous function.
-validate(file) | Uses the `cloudformation:ValidateTemplate` API call to perform rudimentary template validation
+validate(file|stdin) | Uses the `cloudformation:ValidateTemplate` API call to perform rudimentary template validation
 merge(...template) | Merges templates together. Throws errors if logical names are reused
 
 ## CLI tools
@@ -75,4 +75,6 @@ Or, to validate a template:
 ```
 # Make sure that your shell is configured to make AWS requests
 $ validate-template path/to/template.js
+# or to build and validate all at once
+$ build-template path/to/template.js | validate-template
 ```

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,7 +89,7 @@ test('build', (assert) => {
 });
 
 test('validate', (assert) => {
-  assert.plan(2);
+  assert.plan(3);
 
   cloudfriend.validate(path.join(fixtures, 'static.json'))
     .then(function() {
@@ -98,6 +98,17 @@ test('validate', (assert) => {
     })
     .catch(function(err) {
       assert.ok(/Template format error: Unrecognized resource type/.test(err.message), 'invalid');
+    })
+    .then(function() {
+      process.stdin.isTTY = false;
+      var p = cloudfriend.validate('-');
+      var stdin = JSON.stringify(require('./fixtures/static.json'), null, 4);
+      process.stdin.push(stdin);
+      process.stdin.emit('end');
+      return p;
+    })
+    .then(function() {
+      assert.ok(true, 'valid');
     });
 });
 


### PR DESCRIPTION
Currently, `validate-template` requires a file to validate a template.

This PR would allow a user to validate a template passed via standard input.

```sh
# use a pipe
build-template path/to/template.js | validate-template
# or use < if that's your cup o' tea
validate-template < build-template path/to/template.js
# and you can use the traditional "-" as the file name
build-template path/to/template.js | validate-template -
```