### PR TITLE
domainsuffix is urlsuffix

### DIFF
--- a/lib/pseudo.js
+++ b/lib/pseudo.js
@@ -81,13 +81,13 @@ pseudo.stackName = intrinsic.ref('AWS::StackName');
 pseudo.partition = intrinsic.ref('AWS::Partition');
 
 /**
- * [The pseudo parameter AWS::DomainSuffix](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-domainsuffix),
- * a reference to the suffix for a domain. For example, for the www.amazon.com
- * domain, the suffix is .com. Values might differ by region, such as the suffix
- * .com.cn in the China (Beijing) region.
+ * [The pseudo parameter AWS::UrlSuffix](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-urlsuffix),
+ * a reference to the suffix for a service URL. Values might differ by region, such as the suffix .com.cn in the China region.
+ * Currently returns either 'amazonaws.com' for global regions, or 'amazonaws.com.cn' for China regions
  *
+
  * @static
  * @memberof cloudfriend
- * @name domainSuffix
+ * @name urlSuffix
  */
-pseudo.domainSuffix = intrinsic.ref('AWS::DomainSuffix');
+pseudo.urlSuffix = intrinsic.ref('AWS::URLSuffix');

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ region | [AWS::Region](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserG
 stackId | [AWS::StackId](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html)
 stackName | [AWS::StackName](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html)
 partition | [AWS::Partition](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition)
-domainSuffix | [AWS::DomainSuffix](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-domainsuffix)
+urlSuffix | [AWS::URLSuffix](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-urlsuffix)
 
 ## Other helpers
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,7 +45,7 @@ test('pseudo', (assert) => {
   assert.deepEqual(cloudfriend.stackId, { Ref: 'AWS::StackId' }, 'stackId');
   assert.deepEqual(cloudfriend.stackName, { Ref: 'AWS::StackName' }, 'stack');
   assert.deepEqual(cloudfriend.partition, { Ref: 'AWS::Partition' }, 'stack');
-  assert.deepEqual(cloudfriend.domainSuffix, { Ref: 'AWS::DomainSuffix' }, 'stack');
+  assert.deepEqual(cloudfriend.urlSuffix, { Ref: 'AWS::URLSuffix' }, 'stack');
   assert.end();
 });
 


### PR DESCRIPTION
Don't know if AWS changed this pseudo parameter out from under us, but it's `AWS::URLSuffix` not `AWS::DomainSuffix`