### PR TITLE
Validate with region

### DIFF
--- a/bin/validate-template.js
+++ b/bin/validate-template.js
@@ -5,7 +5,6 @@
 var cloudfriend = require('..');
 var templatePath = process.argv[2];
 var region = process.argv[3] || 'us-east-1';
-console.log(region);
 
 cloudfriend.validate(templatePath, region)
   .then(function() {

--- a/bin/validate-template.js
+++ b/bin/validate-template.js
@@ -4,8 +4,10 @@
 
 var cloudfriend = require('..');
 var templatePath = process.argv[2];
+var region = process.argv[3] || 'us-east-1';
+console.log(region);
 
-cloudfriend.validate(templatePath, 'us-east-1')
+cloudfriend.validate(templatePath, region)
   .then(function() {
     console.log('✔ valid');
   }).catch(function(err) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -13,7 +13,7 @@ var build = require('./build');
  * reject if it is not.
  */
 module.exports = (templatePath, region) => {
-  var cfn = new AWS.CloudFormation({ region: region});
+  var cfn = new AWS.CloudFormation({ region: region || 'us-east-1' });
 
   return build(templatePath).then(function(template) {
     return cfn.validateTemplate({ TemplateBody: JSON.stringify(template) }).promise();

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -13,7 +13,7 @@ var build = require('./build');
  * reject if it is not.
  */
 module.exports = (templatePath, region) => {
-  var cfn = new AWS.CloudFormation({ region: region || 'us-east-1' });
+  var cfn = new AWS.CloudFormation({ region: region});
 
   return build(templatePath).then(function(template) {
     return cfn.validateTemplate({ TemplateBody: JSON.stringify(template) }).promise();


### PR DESCRIPTION
This allows for specifying a region when validating templates, e.g. `validate-template cloudformation/cloudfriend.js eu-west-1` 

the template validation seems buggy though: even when specifying "cn-north-1" it may claim "valid", but template validation errors occur on deploy. Not sure if that's an issue on AWS side or if we could be doing something differently.