### PR TITLE
Shortcut bugfixes

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -44,7 +44,7 @@ LogGroup, a Role, an Alarm on function errors, and the Lambda Function itself.
     -   `options.Handler` **[String][23]** See [AWS documentation][29] (optional, default `'index.handler'`)
     -   `options.KmsKeyArn` **[String][23]** See [AWS documentation][30] (optional, default `undefined`)
     -   `options.MemorySize` **[Number][31]** See [AWS documentation][32] (optional, default `128`)
-    -   `options.ReservedConcurrencyExecutions` **[Number][31]** See [AWS documentation][33] (optional, default `undefined`)
+    -   `options.ReservedConcurrentExecutions` **[Number][31]** See [AWS documentation][33] (optional, default `undefined`)
     -   `options.Runtime` **[String][23]** See [AWS documentation][34] (optional, default `'nodejs8.10'`)
     -   `options.Tags` **[Array][35]&lt;[Object][22]>** See [AWS documentation][36] (optional, default `undefined`)
     -   `options.Timeout` **[Number][31]** See [AWS documentation][37] (optional, default `300`)
@@ -137,7 +137,7 @@ mapping.
     function and related resources. Extends [the `options` for a vanilla Lambda
     function][2] with the following additional attributes: (optional, default `{}`)
     -   `options.EventSourceArn` **[String][23]** See [AWS documentation][54]
-    -   `options.ReservedConcurrencyExecutions` **[Number][31]** See [AWS documentation][33]
+    -   `options.ReservedConcurrentExecutions` **[Number][31]** See [AWS documentation][33]
 
 ### Examples
 
@@ -153,7 +153,7 @@ const lambda = new cf.shortcuts.QueueLambda({
     S3Key: 'path/to/code.zip'
   },
   EventSourceArn: cf.getAtt('MyQueue', 'Arn'),
-  ReservedConcurrencyExecutions: 30
+  ReservedConcurrentExecutions: 30
 });
 
 module.exports = cf.merge(myTemplate, lambda);
@@ -256,7 +256,7 @@ to publish messages to the queue.
         within the CloudFormation template. This is also used to construct the logical
         names of the other resources.
     -   `options.VisibilityTimeout` **[Number][31]** See [AWS documentation][64] (optional, default `300`)
-    -   `options.maxReceiveCount` **[Number][31]** See [AWS documentation][65] (optional, default `300`)
+    -   `options.maxReceiveCount` **[Number][31]** See [AWS documentation][65] (optional, default `10`)
     -   `options.ContentBasedDeduplication` **[Boolean][56]** See [AWS documentation][66] (optional, default `undefined`)
     -   `options.DelaySeconds` **[Number][31]** See [AWS documentation][67] (optional, default `undefined`)
     -   `options.FifoQueue` **[Boolean][56]** See [AWS documentation][68] (optional, default `undefined`)

--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -136,7 +136,8 @@ mapping.
 -   `options` **[Object][22]** configuration options for the scheduled Lambda
     function and related resources. Extends [the `options` for a vanilla Lambda
     function][2] with the following additional attributes: (optional, default `{}`)
-    -   `options.EventSourceArn` **[String][23]** See [AWS documentation][54]
+    -   `options.BatchSize` **[Number][31]** See [AWS documentation][54] (optional, default `1`)
+    -   `options.EventSourceArn` **[String][23]** See [AWS documentation][55]
     -   `options.ReservedConcurrentExecutions` **[Number][31]** See [AWS documentation][33]
 
 ### Examples
@@ -172,8 +173,8 @@ source mapping.
 -   `options` **[Object][22]** configuration options for the scheduled Lambda
     function and related resources. Extends [the `options` for a vanilla Lambda
     function][2] with the following additional attributes: (optional, default `{}`)
-    -   `options.EventSourceArn` **[String][23]** See [AWS documentation][54]
-    -   `options.BatchSize` **[Number][31]** See [AWS documentation][55] (optional, default `1`)
+    -   `options.EventSourceArn` **[String][23]** See [AWS documentation][55]
+    -   `options.BatchSize` **[Number][31]** See [AWS documentation][54] (optional, default `1`)
     -   `options.Enabled` **[Boolean][56]** See [AWS documentation][57] (optional, default `true`)
     -   `options.StartingPosition` **[String][23]** See [AWS documentation][58] (optional, default `'LATEST'`)
 
@@ -397,9 +398,9 @@ module.exports = cf.merge(myTemplate, queue);
 
 [53]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-events-rule.html#cfn-events-rule-state
 
-[54]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn
+[54]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-batchsize
 
-[55]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-batchsize
+[55]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn
 
 [56]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 

--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -19,7 +19,7 @@
  * @param {String} [options.Handler='index.handler'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-handler)
  * @param {String} [options.KmsKeyArn=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-kmskeyarn)
  * @param {Number} [options.MemorySize=128] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize)
- * @param {Number} [options.ReservedConcurrencyExecutions=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
+ * @param {Number} [options.ReservedConcurrentExecutions=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
  * @param {String} [options.Runtime='nodejs8.10'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)
  * @param {Array<Object>} [options.Tags=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-tags)
  * @param {Number} [options.Timeout=300] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-timeout)
@@ -70,7 +70,7 @@ class Lambda {
       Handler = 'index.handler',
       KmsKeyArn,
       MemorySize = 128,
-      ReservedConcurrencyExecutions,
+      ReservedConcurrentExecutions,
       Runtime = Code && Code.ZipFile ? 'nodejs6.10' : 'nodejs8.10',
       Tags,
       Timeout = 300,
@@ -166,7 +166,7 @@ class Lambda {
           Handler,
           KmsKeyArn,
           MemorySize,
-          ReservedConcurrencyExecutions,
+          ReservedConcurrentExecutions,
           Role: { 'Fn::GetAtt': [`${LogicalName}Role`, 'Arn'] },
           Runtime,
           Timeout,

--- a/lib/shortcuts/queue-lambda.js
+++ b/lib/shortcuts/queue-lambda.js
@@ -57,7 +57,8 @@ class QueueLambda extends Lambda {
         Effect: 'Allow',
         Action: [
           'sqs:DeleteMessage',
-          'sqs:ReceiveMessage'
+          'sqs:ReceiveMessage',
+          'sqs:GetQueueAttributes'
         ],
         Resource: [
           EventSourceArn,

--- a/lib/shortcuts/queue-lambda.js
+++ b/lib/shortcuts/queue-lambda.js
@@ -11,7 +11,7 @@ const Lambda = require('./lambda');
  * function and related resources. Extends [the `options` for a vanilla Lambda
  * function](#parameters) with the following additional attributes:
  * @param {String} options.EventSourceArn See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn)
- * @param {Number} options.ReservedConcurrencyExecutions See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
+ * @param {Number} options.ReservedConcurrentExecutions See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
  *
  * @example
  * const cf = require('@mapbox/cloudfriend');
@@ -25,7 +25,7 @@ const Lambda = require('./lambda');
  *     S3Key: 'path/to/code.zip'
  *   },
  *   EventSourceArn: cf.getAtt('MyQueue', 'Arn'),
- *   ReservedConcurrencyExecutions: 30
+ *   ReservedConcurrentExecutions: 30
  * });
  *
  * module.exports = cf.merge(myTemplate, lambda);
@@ -34,11 +34,11 @@ class QueueLambda extends Lambda {
   constructor(options = {}) {
     super(options);
 
-    const { EventSourceArn, ReservedConcurrencyExecutions } = options;
+    const { EventSourceArn, ReservedConcurrentExecutions } = options;
 
-    const required = [EventSourceArn, ReservedConcurrencyExecutions];
+    const required = [EventSourceArn, ReservedConcurrentExecutions];
     if (required.some((variable) => !variable))
-      throw new Error('You must provide an EventSourceArn and ReservedConcurrencyExecutions');
+      throw new Error('You must provide an EventSourceArn and ReservedConcurrentExecutions');
 
     const { Enabled = true } = options;
 

--- a/lib/shortcuts/queue-lambda.js
+++ b/lib/shortcuts/queue-lambda.js
@@ -48,7 +48,7 @@ class QueueLambda extends Lambda {
       Properties: {
         Enabled,
         EventSourceArn,
-        FunctionName: this.FunctionName
+        FunctionName: { Ref: this.LogicalName }
       }
     };
 

--- a/lib/shortcuts/queue-lambda.js
+++ b/lib/shortcuts/queue-lambda.js
@@ -10,6 +10,7 @@ const Lambda = require('./lambda');
  * @param {Object} options configuration options for the scheduled Lambda
  * function and related resources. Extends [the `options` for a vanilla Lambda
  * function](#parameters) with the following additional attributes:
+ * @param {Number} [options.BatchSize=1] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-batchsize)
  * @param {String} options.EventSourceArn See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-eventsourcearn)
  * @param {Number} options.ReservedConcurrentExecutions See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
  *
@@ -34,7 +35,11 @@ class QueueLambda extends Lambda {
   constructor(options = {}) {
     super(options);
 
-    const { EventSourceArn, ReservedConcurrentExecutions } = options;
+    const {
+      BatchSize = 1,
+      EventSourceArn,
+      ReservedConcurrentExecutions
+    } = options;
 
     const required = [EventSourceArn, ReservedConcurrentExecutions];
     if (required.some((variable) => !variable))
@@ -47,6 +52,7 @@ class QueueLambda extends Lambda {
       Condition: this.Condition,
       Properties: {
         Enabled,
+        BatchSize,
         EventSourceArn,
         FunctionName: { Ref: this.LogicalName }
       }

--- a/lib/shortcuts/queue.js
+++ b/lib/shortcuts/queue.js
@@ -13,7 +13,7 @@
  * within the CloudFormation template. This is also used to construct the logical
  * names of the other resources.
  * @param {Number} [options.VisibilityTimeout=300] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#aws-sqs-queue-visibilitytimeout)
- * @param {Number} [options.maxReceiveCount=300] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues-redrivepolicy.html#aws-sqs-queue-redrivepolicy-maxcount)
+ * @param {Number} [options.maxReceiveCount=10] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues-redrivepolicy.html#aws-sqs-queue-redrivepolicy-maxcount)
  * @param {Boolean} [options.ContentBasedDeduplication=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#cfn-sqs-queue-contentbaseddeduplication)
  * @param {Number} [options.DelaySeconds=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#aws-sqs-queue-delayseconds)
  * @param {Boolean} [options.FifoQueue=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#cfn-sqs-queue-fifoqueue)

--- a/lib/shortcuts/queue.js
+++ b/lib/shortcuts/queue.js
@@ -108,10 +108,12 @@ class Queue {
         Properties: {
           TopicName,
           DisplayName,
-          Subscription: {
-            Endpoint: { 'Fn::GetAtt': [LogicalName, 'Arn'] },
-            Protocol: 'sqs'
-          }
+          Subscription: [
+            {
+              Endpoint: { 'Fn::GetAtt': [LogicalName, 'Arn'] },
+              Protocol: 'sqs'
+            }
+          ]
         }
       },
 

--- a/lib/shortcuts/stream-lambda.js
+++ b/lib/shortcuts/stream-lambda.js
@@ -53,7 +53,7 @@ class StreamLambda extends Lambda {
         BatchSize,
         Enabled,
         EventSourceArn,
-        FunctionName: this.FunctionName,
+        FunctionName: { Ref: this.LogicalName },
         StartingPosition
       }
     };

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -91,7 +91,7 @@
         "Handler": "index.something",
         "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/fake",
         "MemorySize": 512,
-        "ReservedConcurrencyExecutions": 10,
+        "ReservedConcurrentExecutions": 10,
         "Role": {
           "Fn::GetAtt": [
             "MyLambdaRole",

--- a/test/fixtures/shortcuts/queue-defaults.json
+++ b/test/fixtures/shortcuts/queue-defaults.json
@@ -47,15 +47,17 @@
         "TopicName": {
           "Fn::Sub": "${AWS::StackName}-MyQueue"
         },
-        "Subscription": {
-          "Endpoint": {
-            "Fn::GetAtt": [
-              "MyQueue",
-              "Arn"
-            ]
-          },
-          "Protocol": "sqs"
-        }
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Fn::GetAtt": [
+                "MyQueue",
+                "Arn"
+              ]
+            },
+            "Protocol": "sqs"
+          }
+        ]
       }
     },
     "MyQueuePolicy": {

--- a/test/fixtures/shortcuts/queue-full.json
+++ b/test/fixtures/shortcuts/queue-full.json
@@ -58,15 +58,17 @@
       "Properties": {
         "TopicName": "my-topic",
         "DisplayName": "topic-display-name",
-        "Subscription": {
-          "Endpoint": {
-            "Fn::GetAtt": [
-              "MyQueue",
-              "Arn"
-            ]
-          },
-          "Protocol": "sqs"
-        }
+        "Subscription": [
+          {
+            "Endpoint": {
+              "Fn::GetAtt": [
+                "MyQueue",
+                "Arn"
+              ]
+            },
+            "Protocol": "sqs"
+          }
+        ]
       }
     },
     "MyQueuePolicy": {

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -142,6 +142,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "Enabled": true,
+        "BatchSize": 1,
         "EventSourceArn": "arn:aws:sqs:us-east-1:123456789012:queue/fake",
         "FunctionName": {
           "Ref": "MyLambda"

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -143,7 +143,7 @@
         "Enabled": true,
         "EventSourceArn": "arn:aws:sqs:us-east-1:123456789012:queue/fake",
         "FunctionName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda"
+          "Ref": "MyLambda"
         }
       }
     }

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -56,7 +56,8 @@
                   "Effect": "Allow",
                   "Action": [
                     "sqs:DeleteMessage",
-                    "sqs:ReceiveMessage"
+                    "sqs:ReceiveMessage",
+                    "sqs:GetQueueAttributes"
                   ],
                   "Resource": [
                     "arn:aws:sqs:us-east-1:123456789012:queue/fake",

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -91,7 +91,7 @@
         },
         "Handler": "index.handler",
         "MemorySize": 128,
-        "ReservedConcurrencyExecutions": 10,
+        "ReservedConcurrentExecutions": 10,
         "Role": {
           "Fn::GetAtt": [
             "MyLambdaRole",

--- a/test/fixtures/shortcuts/stream-lambda.json
+++ b/test/fixtures/shortcuts/stream-lambda.json
@@ -149,7 +149,7 @@
         "Enabled": true,
         "EventSourceArn": "arn:aws:sqs:us-east-1:123456789012:queue/fake",
         "FunctionName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda"
+          "Ref": "MyLambda"
         },
         "StartingPosition": "LATEST"
       }

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -79,7 +79,7 @@ test('[shortcuts] lambda', (assert) => {
     Handler: 'index.something',
     KmsKeyArn: 'arn:aws:kms:us-east-1:123456789012:key/fake',
     MemorySize: 512,
-    ReservedConcurrencyExecutions: 10,
+    ReservedConcurrentExecutions: 10,
     Runtime: 'nodejs6.10',
     Tags: [{ Key: 'a', Value: 'b' }],
     Timeout: 30,
@@ -140,7 +140,7 @@ test('[shortcuts] queue-lambda', (assert) => {
         S3Key: 'path/to/code.zip'
       }
     }),
-    /You must provide an EventSourceArn and ReservedConcurrencyExecutions/,
+    /You must provide an EventSourceArn and ReservedConcurrentExecutions/,
     'throws without queue-lambda required parameters'
   );
 
@@ -151,7 +151,7 @@ test('[shortcuts] queue-lambda', (assert) => {
       S3Key: 'path/to/code.zip'
     },
     EventSourceArn: 'arn:aws:sqs:us-east-1:123456789012:queue/fake',
-    ReservedConcurrencyExecutions: 10
+    ReservedConcurrentExecutions: 10
   });
 
   const template = cf.merge(lambda);


### PR DESCRIPTION
- docs incorrectly reported default queue `maxReceiveCount` as 300 instead of 10
- lambda `ReservedConcurrentExecutions` was typo'd everywhere
- queue subscriptions must be a list
- event source mappings need to depend on functions existing first, use a `Ref`
- additional permissions for Lambda functions reading from SQS
- event source mapping for SQS -> Lambda needs a `BatchSize`