### PR TITLE
Lambda principal should always use .com suffix

### DIFF
--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -127,9 +127,7 @@ class Lambda {
                 Effect: 'Allow',
                 Action: 'sts:AssumeRole',
                 Principal: {
-                  Service: {
-                    'Fn::Sub': 'lambda.${AWS::URLSuffix}'
-                  }
+                  Service: 'lambda.amazonaws.com'
                 }
               }
             ]

--- a/test/fixtures/shortcuts/lambda-defaults.json
+++ b/test/fixtures/shortcuts/lambda-defaults.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -37,9 +37,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/lambda-zipfile.json
+++ b/test/fixtures/shortcuts/lambda-zipfile.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/scheduled-lambda-defaults.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-defaults.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/scheduled-lambda-full.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-full.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]

--- a/test/fixtures/shortcuts/stream-lambda.json
+++ b/test/fixtures/shortcuts/stream-lambda.json
@@ -30,9 +30,7 @@
               "Effect": "Allow",
               "Action": "sts:AssumeRole",
               "Principal": {
-                "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
-                }
+                "Service": "lambda.amazonaws.com"
               }
             }
           ]


### PR DESCRIPTION
When in china regions, `${AWS::URLSuffix}` should not be used to define lambda service principals.