### PR TITLE
Add DependsOn support to shortcuts

### DIFF
--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -28,6 +28,8 @@
  * @param {String} [options.Condition=undefined] if there is a Condition defined in the template
  * that should control whether or not to create this Lambda function, specify
  * the name of the condition here. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html)
+ * @param {String} [options.DependsOn=undefined] Specify a stack resource dependency
+ * to this Lambda function. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html)
  * @param {Array<Object>} [options.Statement=[]] an array of policy statements
  * defining the permissions that your Lambda function needs in order to execute.
  * @param {String} [options.AlarmName='${stack name}-${logical name}-Errors'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmname)
@@ -77,6 +79,7 @@ class Lambda {
       TracingConfig,
       VpcConfig,
       Condition = undefined,
+      DependsOn = undefined,
       Statement = [],
       AlarmName = { 'Fn::Sub': `\${AWS::StackName}-${LogicalName}-Errors` },
       AlarmDescription = {
@@ -155,6 +158,7 @@ class Lambda {
       [`${LogicalName}`]: {
         Type: 'AWS::Lambda::Function',
         Condition,
+        DependsOn,
         Properties: {
           Code,
           DeadLetterConfig,

--- a/lib/shortcuts/queue.js
+++ b/lib/shortcuts/queue.js
@@ -26,6 +26,8 @@
  * @param {String} [options.Condition=undefined] if there is a Condition defined
  * in the template that should control whether or not to create this SQS queue,
  * specify the name of the condition here. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html)
+ * @param {String} [options.DependsOn=undefined] Specify a stack resource dependency
+ * to this SQS queue. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html)
  * @param {String} [options.TopicName='${stack name}-${logical name}'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html#cfn-sns-topic-name)
  * @param {String} [options.DisplayName=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sns-topic.html#cfn-sns-topic-displayname)
  * @param {Number} [options.DeadLetterVisibilityTimeout=300] [VisibilityTimeout](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html#aws-sqs-queue-visibilitytimeout) for the dead-letter queue
@@ -57,6 +59,7 @@ class Queue {
       QueueName = { 'Fn::Sub': `\${AWS::StackName}-${LogicalName}` },
       ReceiveMessageWaitTimeSeconds,
       Condition = undefined,
+      DependsOn = undefined,
       TopicName = { 'Fn::Sub': `\${AWS::StackName}-${LogicalName}` },
       DisplayName,
       DeadLetterVisibilityTimeout = 300
@@ -70,6 +73,7 @@ class Queue {
       [LogicalName]: {
         Type: 'AWS::SQS::Queue',
         Condition,
+        DependsOn,
         Properties: {
           ContentBasedDeduplication,
           DelaySeconds,

--- a/lib/shortcuts/service-role.js
+++ b/lib/shortcuts/service-role.js
@@ -80,18 +80,19 @@ class ServiceRole {
                 Principal: { Service }
               }
             ]
-          },
-          Policies: [
-            {
-              PolicyName: 'main',
-              PolicyDocument: {
-                Statement
-              }
-            }
-          ]
+          }
         }
       }
     };
+
+    if (Statement.length) this.Resources[LogicalName].Properties.Policies = [
+      {
+        PolicyName: 'main',
+        PolicyDocument: {
+          Statement
+        }
+      }
+    ];
   }
 }
 

--- a/lib/shortcuts/service-role.js
+++ b/lib/shortcuts/service-role.js
@@ -18,6 +18,8 @@
  * @param {String} [options.Condition=undefined] if there is a Condition defined
  * in the template that should control whether or not to create this IAM role,
  * specify the name of the condition here. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html)
+ * @param {String} [options.DependsOn=undefined] Specify a stack resource dependency
+ * to this IAM role. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html)
  * @example
  * const cf = require('@mapbox/cloudfriend');
  *
@@ -46,7 +48,8 @@ class ServiceRole {
       MaxSessionDuration,
       Path,
       RoleName,
-      Condition = undefined
+      Condition = undefined,
+      DependsOn = undefined
     } = options;
 
     let { Service } = options;
@@ -63,6 +66,7 @@ class ServiceRole {
       [LogicalName]: {
         Type: 'AWS::IAM::Role',
         Condition,
+        DependsOn,
         Properties: {
           ManagedPolicyArns,
           MaxSessionDuration,

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -12,6 +12,9 @@
     }
   },
   "Resources": {
+    "AnotherThing": {
+      "Type": "AWS::SNS::Topic"
+    },
     "MyLambdaLogs": {
       "Type": "AWS::Logs::LogGroup",
       "Condition": "Always",
@@ -71,6 +74,7 @@
     "MyLambda": {
       "Type": "AWS::Lambda::Function",
       "Condition": "Always",
+      "DependsOn": "AnotherThing",
       "Properties": {
         "Code": {
           "S3Bucket": "my-code-bucket",

--- a/test/fixtures/shortcuts/queue-full.json
+++ b/test/fixtures/shortcuts/queue-full.json
@@ -12,9 +12,13 @@
     }
   },
   "Resources": {
+    "AnotherThing": {
+      "Type": "AWS::SNS::Topic"
+    },
     "MyQueue": {
       "Type": "AWS::SQS::Queue",
       "Condition": "Always",
+      "DependsOn": "AnotherThing",
       "Properties": {
         "ContentBasedDeduplication": true,
         "DelaySeconds": 60,

--- a/test/fixtures/shortcuts/service-role-defaults.json
+++ b/test/fixtures/shortcuts/service-role-defaults.json
@@ -20,15 +20,7 @@
               }
             }
           ]
-        },
-        "Policies": [
-          {
-            "PolicyName": "main",
-            "PolicyDocument": {
-              "Statement": []
-            }
-          }
-        ]
+        }
       }
     }
   },

--- a/test/fixtures/shortcuts/service-role-no-defaults.json
+++ b/test/fixtures/shortcuts/service-role-no-defaults.json
@@ -12,9 +12,13 @@
     }
   },
   "Resources": {
+    "AnotherThing": {
+      "Type": "AWS::SNS::Topic"
+    },
     "MyRole": {
       "Type": "AWS::IAM::Role",
       "Condition": "Always",
+      "DependsOn": "AnotherThing",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::123456789012:policy/fake"

--- a/test/fixtures/shortcuts/service-role-suffix-replace.json
+++ b/test/fixtures/shortcuts/service-role-suffix-replace.json
@@ -20,15 +20,7 @@
               }
             }
           ]
-        },
-        "Policies": [
-          {
-            "PolicyName": "main",
-            "PolicyDocument": {
-              "Statement": []
-            }
-          }
-        ]
+        }
       }
     }
   },

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -89,6 +89,7 @@ test('[shortcuts] lambda', (assert) => {
       SubnetIds: ['fake']
     },
     Condition: 'Always',
+    DependsOn: 'AnotherThing',
     Statement: [
       {
         Effect: 'Allow',
@@ -110,11 +111,11 @@ test('[shortcuts] lambda', (assert) => {
     OKActions: ['devnull@mapbox.com']
   });
 
-  template = cf.merge({
-    Conditions: {
-      Always: cf.equals('1', '1')
-    }
-  }, lambda);
+  template = cf.merge(
+    { Conditions: { Always: cf.equals('1', '1') } },
+    { Resources: { AnotherThing: { Type: 'AWS::SNS::Topic' } } },
+    lambda
+  );
   if (update) fixtures.update('lambda-full', template);
   assert.deepEqual(
     noUndefined(template),
@@ -294,6 +295,7 @@ test('[shortcuts] queue', (assert) => {
     QueueName: 'my-queue',
     ReceiveMessageWaitTimeSeconds: 20,
     Condition: 'Always',
+    DependsOn: 'AnotherThing',
     TopicName: 'my-topic',
     DisplayName: 'topic-display-name',
     DeadLetterVisibilityTimeout: 60
@@ -301,6 +303,7 @@ test('[shortcuts] queue', (assert) => {
 
   template = cf.merge(
     { Conditions: { Always: cf.equals('1', '1') } },
+    { Resources: { AnotherThing: { Type: 'AWS::SNS::Topic' } } },
     queue
   );
   if (update) fixtures.update('queue-full', template);
@@ -313,7 +316,7 @@ test('[shortcuts] queue', (assert) => {
   assert.end();
 });
 
-test('[shortcuts]', (assert) => {
+test('[shortcuts] service-role', (assert) => {
   assert.throws(
     () => new cf.shortcuts.ServiceRole(),
     /You must provide a LogicalName and Service/,
@@ -362,11 +365,13 @@ test('[shortcuts]', (assert) => {
     MaxSessionDuration: 60,
     Path: '/fake',
     RoleName: 'my-role',
-    Condition: 'Always'
+    Condition: 'Always',
+    DependsOn: 'AnotherThing'
   });
 
   template = cf.merge(
     { Conditions: { Always: cf.equals('1', '1') } },
+    { Resources: { AnotherThing: { Type: 'AWS::SNS::Topic' } } },
     role
   );
   if (update) fixtures.update('service-role-no-defaults', template);


### PR DESCRIPTION
Adds support for [DependsOn](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) to existing shortcuts.