### PR TITLE
Allow developer to ask for detailed logging/metrics with hookshot

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -339,7 +339,11 @@ you return from your Lambda function will be modified to include CORS headers.
     have written which will receive a request and generate a response to provide
     to the caller.
 -   `LoggingLevel` **[String][31]** one of `OFF`, `INFO`, or `ERROR`. Logs are delivered
-    to a CloudWatch LogGroup named `API-Gateway-Execution-Logs_{rest-api-id}/hookshot`
+    to a CloudWatch LogGroup named `API-Gateway-Execution-Logs_{rest-api-id}/hookshot` (optional, default `'OFF'`)
+-   `DataTraceEnabled` **[Boolean][65]** set to `true` to enable full request/response
+    logging in the API's execution logs. (optional, default `false`)
+-   `MetricsEnabled` **[Boolean][65]** set to `true` to enable additional
+    execution metrics in CloudWatch. (optional, default `false`)
 
 ### Properties
 

--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -344,6 +344,9 @@ you return from your Lambda function will be modified to include CORS headers.
     logging in the API's execution logs. (optional, default `false`)
 -   `MetricsEnabled` **[Boolean][65]** set to `true` to enable additional
     execution metrics in CloudWatch. (optional, default `false`)
+-   `AccessLogFormat` **[String][31]?** A single line format of the access logs of
+    data, as specified by selected $context variables. The format must include at
+    least $context.requestId. [See AWS documentation for details][88].
 
 ### Properties
 
@@ -600,3 +603,5 @@ module.exports = cf.merge(myTemplate, lambda);
 [86]: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
 
 [87]: https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format
+
+[88]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-accesslogsetting.html#cfn-apigateway-stage-accesslogsetting-format

--- a/lib/shortcuts/hookshot.js
+++ b/lib/shortcuts/hookshot.js
@@ -43,8 +43,12 @@ const random = crypto.randomBytes(4).toString('hex');
  * @param {String} PassthroughTo the logical name of the Lambda function that you
  * have written which will receive a request and generate a response to provide
  * to the caller.
- * @param {String} LoggingLevel one of `OFF`, `INFO`, or `ERROR`. Logs are delivered
+ * @param {String} [LoggingLevel='OFF'] one of `OFF`, `INFO`, or `ERROR`. Logs are delivered
  * to a CloudWatch LogGroup named `API-Gateway-Execution-Logs_{rest-api-id}/hookshot`
+ * @param {Boolean} [DataTraceEnabled=false] set to `true` to enable full request/response
+ * logging in the API's execution logs.
+ * @param {Boolean} [MetricsEnabled=false] set to `true` to enable additional
+ * execution metrics in CloudWatch.
  *
  * @example
  * const cf = require('@mapbox/cloudfriend');
@@ -71,6 +75,11 @@ class Passthrough {
     const {
       Prefix,
       PassthroughTo,
+      DataTraceEnabled = false,
+      MetricsEnabled = false
+    } = options;
+
+    let {
       LoggingLevel = 'OFF'
     } = options;
 
@@ -78,8 +87,11 @@ class Passthrough {
     if (required.some((variable) => !variable))
       throw new Error('You must provide a Prefix, and PassthroughTo');
 
-    if (LoggingLevel && !['OFF', 'INFO', 'ERROR'].includes(LoggingLevel))
+    if (!['OFF', 'INFO', 'ERROR'].includes(LoggingLevel))
       throw new Error('LoggingLevel must be one of OFF, INFO, or ERROR');
+
+    if (DataTraceEnabled)
+      LoggingLevel = LoggingLevel === 'OFF' ? 'ERROR' : LoggingLevel;
 
     this.Prefix = Prefix;
     this.PassthroughTo = PassthroughTo;
@@ -112,7 +124,9 @@ class Passthrough {
               ResourcePath: '/*',
               ThrottlingBurstLimit: 20,
               ThrottlingRateLimit: 5,
-              LoggingLevel: LoggingLevel
+              LoggingLevel,
+              DataTraceEnabled,
+              MetricsEnabled
             }
           ]
         }

--- a/lib/shortcuts/hookshot.js
+++ b/lib/shortcuts/hookshot.js
@@ -49,6 +49,9 @@ const random = crypto.randomBytes(4).toString('hex');
  * logging in the API's execution logs.
  * @param {Boolean} [MetricsEnabled=false] set to `true` to enable additional
  * execution metrics in CloudWatch.
+ * @param {String} [AccessLogFormat] A single line format of the access logs of
+ * data, as specified by selected $context variables. The format must include at
+ * least $context.requestId. [See AWS documentation for details](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-accesslogsetting.html#cfn-apigateway-stage-accesslogsetting-format).
  *
  * @example
  * const cf = require('@mapbox/cloudfriend');
@@ -75,6 +78,7 @@ class Passthrough {
     const {
       Prefix,
       PassthroughTo,
+      AccessLogFormat,
       DataTraceEnabled = false,
       MetricsEnabled = false
     } = options;
@@ -178,6 +182,21 @@ class Passthrough {
         }
       }
     };
+
+    if (AccessLogFormat) {
+      Resources[`${Prefix}AccessLogs`] = {
+        Type: 'AWS::Logs::LogGroup',
+        Properties: {
+          LogGroupName: { 'Fn::Sub': `\${AWS::StackName}-${Prefix}-access-logs` },
+          RetentionInDays: 14
+        }
+      };
+
+      Resources[`${Prefix}Stage`].Properties.MethodSettings[0].AccessLogSetting = {
+        DestinationArn: { 'Fn::GetAtt': [`${Prefix}AccessLogs`, 'Arn'] },
+        Format: AccessLogFormat
+      };
+    }
 
     const lambda = new Lambda(
       Object.assign({}, options, {

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment4d92664b"
+          "Ref": "PassDeploymentc8119049"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -36,12 +36,14 @@
             "ResourcePath": "/*",
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
-            "LoggingLevel": "OFF"
+            "LoggingLevel": "OFF",
+            "DataTraceEnabled": false,
+            "MetricsEnabled": false
           }
         ]
       }
     },
-    "PassDeployment4d92664b": {
+    "PassDeploymentc8119049": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeploymentc8119049"
+          "Ref": "PassDeployment60b3cb7b"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +43,7 @@
         ]
       }
     },
-    "PassDeploymentc8119049": {
+    "PassDeployment60b3cb7b": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
@@ -36,9 +36,18 @@
             "ResourcePath": "/*",
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
-            "LoggingLevel": "INFO",
-            "DataTraceEnabled": true,
-            "MetricsEnabled": true
+            "LoggingLevel": "OFF",
+            "DataTraceEnabled": false,
+            "MetricsEnabled": false,
+            "AccessLogSetting": {
+              "DestinationArn": {
+                "Fn::GetAtt": [
+                  "PassAccessLogs",
+                  "Arn"
+                ]
+              },
+              "Format": "{ \"requestId\":\"$context.requestId\" }"
+            }
           }
         ]
       }
@@ -121,6 +130,15 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassAccessLogs": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": "${AWS::StackName}-Pass-access-logs"
+        },
+        "RetentionInDays": 14
       }
     },
     "PassFunctionLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment4d92664b"
+          "Ref": "PassDeploymentc8119049"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -36,12 +36,14 @@
             "ResourcePath": "/*",
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
-            "LoggingLevel": "OFF"
+            "LoggingLevel": "OFF",
+            "DataTraceEnabled": false,
+            "MetricsEnabled": false
           }
         ]
       }
     },
-    "PassDeployment4d92664b": {
+    "PassDeploymentc8119049": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeploymentc8119049"
+          "Ref": "PassDeployment60b3cb7b"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +43,7 @@
         ]
       }
     },
-    "PassDeploymentc8119049": {
+    "PassDeployment60b3cb7b": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -36,9 +36,9 @@
             "ResourcePath": "/*",
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
-            "LoggingLevel": "INFO",
-            "DataTraceEnabled": false,
-            "MetricsEnabled": false
+            "LoggingLevel": "ERROR",
+            "DataTraceEnabled": true,
+            "MetricsEnabled": true
           }
         ]
       }

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeploymentc8119049"
+          "Ref": "PassDeployment60b3cb7b"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +43,7 @@
         ]
       }
     },
-    "PassDeploymentc8119049": {
+    "PassDeployment60b3cb7b": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
@@ -37,8 +37,8 @@
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
             "LoggingLevel": "INFO",
-            "DataTraceEnabled": false,
-            "MetricsEnabled": false
+            "DataTraceEnabled": true,
+            "MetricsEnabled": true
           }
         ]
       }

--- a/test/fixtures/shortcuts/hookshot-passthrough-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-logging.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeploymentc8119049"
+          "Ref": "PassDeployment60b3cb7b"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +43,7 @@
         ]
       }
     },
-    "PassDeploymentc8119049": {
+    "PassDeployment60b3cb7b": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment4d92664b"
+          "Ref": "PassDeploymentc8119049"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -36,12 +36,14 @@
             "ResourcePath": "/*",
             "ThrottlingBurstLimit": 20,
             "ThrottlingRateLimit": 5,
-            "LoggingLevel": "OFF"
+            "LoggingLevel": "OFF",
+            "DataTraceEnabled": false,
+            "MetricsEnabled": false
           }
         ]
       }
     },
-    "PassDeployment4d92664b": {
+    "PassDeploymentc8119049": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -24,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeploymentc8119049"
+          "Ref": "PassDeployment60b3cb7b"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +43,7 @@
         ]
       }
     },
-    "PassDeploymentc8119049": {
+    "PassDeployment60b3cb7b": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -456,6 +456,37 @@ test('[shortcuts] hookshot passthrough', (assert) => {
     'expected resources generated with configured LoggingLevel'
   );
 
+  passthrough = new cf.shortcuts.hookshot.Passthrough({
+    Prefix: 'Pass',
+    PassthroughTo: 'Destination',
+    DataTraceEnabled: true,
+    MetricsEnabled: true
+  });
+
+  template = cf.merge(passthrough, to);
+  if (update) fixtures.update('hookshot-passthrough-enhanced-logging', template);
+  assert.deepEqual(
+    normalizeDeployment(noUndefined(template)),
+    normalizeDeployment(fixtures.get('hookshot-passthrough-enhanced-logging')),
+    'expected resources generated with detailed logging and metrics'
+  );
+
+  passthrough = new cf.shortcuts.hookshot.Passthrough({
+    Prefix: 'Pass',
+    PassthroughTo: 'Destination',
+    DataTraceEnabled: true,
+    MetricsEnabled: true,
+    LoggingLevel: 'INFO'
+  });
+
+  template = cf.merge(passthrough, to);
+  if (update) fixtures.update('hookshot-passthrough-full-blown-logging', template);
+  assert.deepEqual(
+    normalizeDeployment(noUndefined(template)),
+    normalizeDeployment(fixtures.get('hookshot-passthrough-full-blown-logging')),
+    'LoggingLevel respected with detailed logging and metrics'
+  );
+
   assert.end();
 });
 

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -487,6 +487,20 @@ test('[shortcuts] hookshot passthrough', (assert) => {
     'LoggingLevel respected with detailed logging and metrics'
   );
 
+  passthrough = new cf.shortcuts.hookshot.Passthrough({
+    Prefix: 'Pass',
+    PassthroughTo: 'Destination',
+    AccessLogFormat: '{ "requestId":"$context.requestId" }'
+  });
+
+  template = cf.merge(passthrough, to);
+  if (update) fixtures.update('hookshot-passthrough-access-log-format', template);
+  assert.deepEqual(
+    normalizeDeployment(noUndefined(template)),
+    normalizeDeployment(fixtures.get('hookshot-passthrough-access-log-format')),
+    'expected resources generated with access logs'
+  );
+
   assert.end();
 });
 


### PR DESCRIPTION
More logging sugar for hookshot on the heels of #45. These new options allow you to ask for detailed request/response logging and/or more details CloudWatch metrics.