### PR TITLE
Add region to Lambda alarm names

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -65,7 +65,7 @@ LogGroup, a Role, an Alarm on function errors, and the Lambda Function itself.
         to this Lambda function. See [AWS documentation][49] (optional, default `undefined`)
     -   `options.Statement` **[Array][43]&lt;[Object][30]>** an array of policy statements
         defining the permissions that your Lambda function needs in order to execute. (optional, default `[]`)
-    -   `options.AlarmName` **[String][31]** See [AWS documentation][50] (optional, default `'${stack name}-${logical name}-Errors'`)
+    -   `options.AlarmName` **[String][31]** See [AWS documentation][50] (optional, default `'${stack name}-${logical name}-Errors-${region}'`)
     -   `options.AlarmDescription` **[String][31]** See [AWS documentation][51] (optional, default `'Error alarm for ${stack name}-${logical name} lambda function in ${stack name} stack'`)
     -   `options.AlarmActions` **[Array][43]&lt;[String][31]>** See [AWS documentation][52] (optional, default `[]`)
     -   `options.Period` **[Number][39]** See [AWS documentation][53] (optional, default `60`)

--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -32,7 +32,7 @@
  * to this Lambda function. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html)
  * @param {Array<Object>} [options.Statement=[]] an array of policy statements
  * defining the permissions that your Lambda function needs in order to execute.
- * @param {String} [options.AlarmName='${stack name}-${logical name}-Errors'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmname)
+ * @param {String} [options.AlarmName='${stack name}-${logical name}-Errors-${region}'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmname)
  * @param {String} [options.AlarmDescription='Error alarm for ${stack name}-${logical name} lambda function in ${stack name} stack'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmdescription)
  * @param {Array<String>} [options.AlarmActions=[]] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-alarmactions)
  * @param {Number} [options.Period=60] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-period)
@@ -81,7 +81,7 @@ class Lambda {
       Condition = undefined,
       DependsOn = undefined,
       Statement = [],
-      AlarmName = { 'Fn::Sub': `\${AWS::StackName}-${LogicalName}-Errors` },
+      AlarmName = { 'Fn::Sub': `\${AWS::StackName}-${LogicalName}-Errors-\${AWS::Region}` },
       AlarmDescription = {
         'Fn::Sub': [
           'Error alarm for ${name} lambda function in ${AWS::StackName} stack',

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -229,7 +229,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -339,7 +339,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
@@ -232,7 +232,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -342,7 +342,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -214,7 +214,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -326,7 +326,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -214,7 +214,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -324,7 +324,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
@@ -214,7 +214,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -324,7 +324,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-logging.json
@@ -214,7 +214,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -324,7 +324,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -214,7 +214,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors"
+          "Fn::Sub": "${AWS::StackName}-PassFunction-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [
@@ -324,7 +324,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-Destination-Errors"
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/lambda-defaults.json
+++ b/test/fixtures/shortcuts/lambda-defaults.json
@@ -85,7 +85,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/lambda-zipfile.json
+++ b/test/fixtures/shortcuts/lambda-zipfile.json
@@ -84,7 +84,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -105,7 +105,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/scheduled-lambda-defaults.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-defaults.json
@@ -85,7 +85,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/scheduled-lambda-full.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-full.json
@@ -85,7 +85,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [

--- a/test/fixtures/shortcuts/stream-lambda.json
+++ b/test/fixtures/shortcuts/stream-lambda.json
@@ -109,7 +109,7 @@
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
         "AlarmName": {
-          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors"
+          "Fn::Sub": "${AWS::StackName}-MyLambda-Errors-${AWS::Region}"
         },
         "AlarmDescription": {
           "Fn::Sub": [


### PR DESCRIPTION
For increased clarity as to where alarms are occurring, adds the region to the alarm names defined by the Lambda shortcut.