### PR TITLE
Hookshot via lambda-backed load balancer

### DIFF
--- a/lib/shortcuts/hookshot.js
+++ b/lib/shortcuts/hookshot.js
@@ -454,7 +454,311 @@ class Github extends Passthrough {
   }
 }
 
+class LoadBalancer {
+  constructor(options = {}) {
+    const {
+      PassthroughTo,
+      SecurityGroups,
+      Subnets,
+      AccessLogBucket,
+      AccessLogPrefix,
+      CertificateArn,
+      Github = false,
+      HTTP = true,
+      HTTPS = false,
+      HealthCheckPath = '/status',
+      Prefix = 'Hookshot',
+      WebhookSecret
+    } = options;
+
+    const required = [PassthroughTo, SecurityGroups, Subnets];
+    if (required.some((variable) => !variable))
+      throw new Error('You must provide PassthroughTo, SecurityGroups, and Subnets');
+
+    if (AccessLogPrefix && !AccessLogBucket)
+      throw new Error('If AccessLogPrefix is specified, must provide an AccessLogBucket');
+
+    if (HTTPS && !CertificateArn)
+      throw new Error('If HTTPS is enabled, must provide a CertificateArn');
+
+    this.Resources = {
+      [`${Prefix}LoadBalancer`]: {
+        Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+        Properties: {
+          IpAddressType: 'ipv4',
+          Name: { 'Fn::Sub': ['${AWS::StackName}-${prefix}', { prefix: Prefix.toLowerCase() }] },
+          Scheme: 'internet-facing',
+          SecurityGroups,
+          Subnets,
+          Type: 'application'
+        }
+      },
+      [`${Prefix}TargetGroup`] : {
+        Type: 'AWS::CloudFormation::CustomResource',
+        Properties: {
+          ServiceToken: { 'Fn::GetAtt': [`${Prefix}TargetGroupCustomResource`, 'Arn'] },
+          Name: { 'Fn::Sub': ['${AWS::StackName}-${prefix}', { prefix: Prefix.toLowerCase() }] },
+          HealthCheckPath
+        }
+      },
+      [`${Prefix}InvocationPermission`]: {
+        Type: 'AWS::Lambda::Permission',
+        Properties: {
+          Action: 'lambda:InvokeFunction',
+          FunctionName: Github
+            ? { 'Fn::GetAtt': [`${Prefix}SignatureVerification`, 'Arn'] }
+            : { 'Fn::GetAtt': [PassthroughTo, 'Arn'] },
+          Principal: 'elasticloadbalancing.amazonaws.com',
+          SourceArn: { 'Fn::GetAtt': [`${Prefix}TargetGroup`, 'Arn'] }
+        }
+      },
+      [`${Prefix}TargetGroupRegistration`]: {
+        Type: 'AWS::CloudFormation::CustomResource',
+        DependsOn: `${Prefix}InvocationPermission`,
+        Properties: {
+          ServiceToken: { 'Fn::GetAtt': [`${Prefix}TargetGroupRegistrationCustomResource`, 'Arn'] },
+          TargetGroupArn: { 'Fn::GetAtt': [`${Prefix}TargetGroup`, 'Arn'] },
+          LambdaFunctionArn: Github
+            ? { 'Fn::GetAtt': [`${Prefix}SignatureVerification`, 'Arn'] }
+            : { 'Fn::GetAtt': [PassthroughTo, 'Arn'] }
+        }
+      }
+    };
+
+    if (AccessLogBucket) {
+      this.Resources[`${Prefix}LoadBalancer`].Properties.LoadBalancerAttributes = [
+        { Key: 'access_logs.s3.enabled', Value: 'true' },
+        { Key: 'access_logs.s3.bucket', Value: AccessLogBucket },
+        { Key: 'access_logs.s3.prefix', Value: AccessLogPrefix || 'elb2' }
+      ];
+    }
+
+    const targetGroupCustomResource = new Lambda({
+      LogicalName: `${Prefix}TargetGroupCustomResource`,
+      FunctionName: {
+        'Fn::Sub': [
+          '${AWS::StackName}-${prefix}-target-group-custom-resource',
+          { prefix: Prefix.toLowerCase() }
+        ]
+      },
+      Code: {
+        ZipFile: `module.exports.handler = function ${this.targetGroup.toString()};`
+      },
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: [
+            'elasticloadbalancing:CreateTargetGroup',
+            'elasticloadbalancing:DeleteTargetGroup',
+            'elasticloadbalancing:ModifyTargetGroup',
+            'elasticloadbalancing:ModifyTargetGroupAttributes'
+          ],
+          Resource: '*'
+        }
+      ]
+    });
+
+    const targetGroupRegistrationCustomResource = new Lambda({
+      LogicalName: `${Prefix}TargetGroupRegistrationCustomResource`,
+      FunctionName: {
+        'Fn::Sub': [
+          '${AWS::StackName}-${prefix}-target-group-registration-custom-resource',
+          { prefix: Prefix.toLowerCase() }
+        ]
+      },
+      Code: {
+        ZipFile: `module.exports.handler = function ${this.targetGroupRegistration.toString()};`
+      },
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 'elasticloadbalancing:RegisterTargets',
+          Resource: '*'
+        }
+      ]
+    });
+
+    Object.assign(
+      this.Resources,
+      targetGroupCustomResource.Resources,
+      targetGroupRegistrationCustomResource.Resources
+    );
+
+    if (HTTP) {
+      this.Resources[`${Prefix}HttpListener`] = {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          DefaultActions: [
+            {
+              TargetGroupArn: { 'Fn::GetAtt': [`${Prefix}TargetGroup`, 'Arn'] },
+              Type: 'forward'
+            }
+          ],
+          LoadBalancerArn: { Ref: `${Prefix}LoadBalancer` },
+          Port: 80,
+          Protocol: 'HTTP'
+        }
+      };
+    }
+
+    if (HTTPS) {
+      this.Resources[`${Prefix}HttpsListener`] = {
+        Type: 'AWS::ElasticLoadBalancingV2::Listener',
+        Properties: {
+          DefaultActions: [
+            {
+              TargetGroupArn: { 'Fn::GetAtt': [`${Prefix}TargetGroup`, 'Arn'] },
+              Type: 'forward'
+            }
+          ],
+          LoadBalancerArn: { Ref: `${Prefix}LoadBalancer` },
+          Port: 443,
+          Protocol: 'HTTPS',
+          Certificates: [CertificateArn]
+        }
+      };
+    }
+
+    if (Github) {
+      const verification = new Lambda({
+        LogicalName: `${Prefix}SignatureVerification`,
+        FunctionName: {
+          'Fn::Sub': [
+            '${AWS::StackName}-${prefix}-signature-verification',
+            { prefix: Prefix.toLowerCase() }
+          ]
+        },
+        Code: {
+          ZipFile: {
+            'Fn::Sub': [
+              `module.exports.handler = function ${this.github.toString()};`,
+              { WebhookSecret, PassthroughTo }
+            ]
+          }
+        }
+      });
+
+      Object.assign(
+        this.Resources,
+        verification.Resources
+      );
+    }
+  }
+
+  targetGroup(event, context) {
+    const response = require('cfn-response');
+    const AWS = require('aws-sdk');
+    const elb = new AWS.ELBv2();
+
+    const main = async () => {
+      const {
+        RequestType,
+        PhysicalResourceId,
+        ResourceProperties
+      } = event;
+
+      if (RequestType.toUpperCase() === 'CREATE') {
+        const { TargetGroups } = await elb.createTargetGroup({
+          Name: ResourceProperties.Name,
+          HealthCheckIntervalSeconds: 30,
+          HealthCheckPath: ResourceProperties.HealthCheckPath,
+          HealthCheckTimeoutSeconds: 5,
+          HealthyThresholdCount: 3,
+          UnhealthyThresholdCount: 3,
+          TargetType: 'lambda'
+        }).promise();
+
+        const data = { Arn: TargetGroups[0].TargetGroupArn };
+        const cleanup = () => elb.deleteTargetGroup({ TargetGroupArn: data.Arn }).promise();
+
+        await elb.modifyTargetGroupAttributes({
+          TargetGroupArn: data.Arn,
+          Attributes: [{ Key: 'lambda.multi_value_headers.enabled', Value: 'true' }]
+        }).promise()
+          .catch(async (err) => { await cleanup(); throw err; });
+
+        response.send(event, context, response.SUCCESS, data, data.Arn);
+      }
+
+      if (RequestType.toUpperCase() === 'UPDATE') {
+        response.send(event, context, response.SUCCESS);
+      }
+
+      if (RequestType.toUpperCase() === 'DELETE') {
+        if (PhysicalResourceId) await elb.deleteTargetGroup({ TargetGroupArn: PhysicalResourceId }).promise();
+        response.send(event, context, response.SUCCESS);
+      }
+    };
+
+    main().catch((err) => { console.log(err); response.send(event, context, response.FAILED); });
+  }
+
+  targetGroupRegistration(event, context) {
+    const response = require('cfn-response');
+    const AWS = require('aws-sdk');
+    const elb = new AWS.ELBv2();
+
+    const {
+      RequestType,
+      ResourceProperties
+    } = event;
+
+    const main = async () => {
+      if (RequestType.toUpperCase() === 'CREATE') {
+        await elb.registerTargets({
+          TargetGroupArn: ResourceProperties.TargetGroupArn,
+          Targets: [{ Id: ResourceProperties.LambdaFunctionArn }]
+        }).promise();
+
+        response.send(event, context, response.SUCCESS);
+      }
+
+      if (RequestType.toUpperCase() === 'UPDATE') {
+        response.send(event, context, response.SUCCESS);
+      }
+
+      if (RequestType.toUpperCase() === 'DELETE') {
+        response.send(event, context, response.SUCCESS);
+      }
+    };
+
+    main().catch((err) => { console.log(err); response.send(event, context, response.FAILED); });
+  }
+
+  github(event, context, callback) {
+    const crypto = require('crypto');
+    const AWS = require('aws-sdk');
+    const lambda = new AWS.Lambda();
+    const secret = '${WebhookSecret}';
+
+    const body = event.body;
+    const hash = 'sha1=' + crypto
+      .createHmac('sha1', secret)
+      .update(new Buffer(JSON.stringify(body)))
+      .digest('hex');
+
+    if (event.headers.signature !== hash)
+      return callback('invalid: signature does not match');
+
+    if (body.zen) return callback(null, 'ignored ping request');
+
+    const lambdaParams = {
+      FunctionName: '${PassthroughTo}',
+      Payload: JSON.stringify(event.body),
+      InvocationType: 'Event'
+    };
+
+    lambda.invoke(lambdaParams).promise()
+      .then(() => callback(null, {
+        statusCode: 202,
+        statusDescription: '202 OK'
+      }))
+      .catch((err) => callback(err));
+  }
+}
+
 module.exports = {
   Passthrough,
-  Github
+  Github,
+  LoadBalancer
 };

--- a/lib/shortcuts/hookshot.js
+++ b/lib/shortcuts/hookshot.js
@@ -493,7 +493,7 @@ class LoadBalancer {
           Type: 'application'
         }
       },
-      [`${Prefix}TargetGroup`] : {
+      [`${Prefix}TargetGroup`]: {
         Type: 'AWS::CloudFormation::CustomResource',
         Properties: {
           ServiceToken: { 'Fn::GetAtt': [`${Prefix}TargetGroupCustomResource`, 'Arn'] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,207 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@mapbox/eslint-config-mapbox": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@mapbox/eslint-config-mapbox/-/eslint-config-mapbox-1.2.1.tgz",
@@ -1388,6 +1589,12 @@
       "integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
       "dev": true
     },
+    "cfn-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cfn-response/-/cfn-response-1.0.1.tgz",
+      "integrity": "sha1-qOwDlQwGg8UUlejKaA2dwLiEsTc=",
+      "dev": true
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2516,7 +2723,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2537,12 +2745,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2557,17 +2767,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2684,7 +2897,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2696,6 +2910,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2710,6 +2925,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2717,12 +2933,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2741,6 +2959,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2821,7 +3040,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2833,6 +3053,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2918,7 +3139,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2954,6 +3176,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2973,6 +3196,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3016,12 +3240,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3786,6 +4012,27 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
+        "semver": "^5.5.0"
+      }
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
@@ -4323,83 +4570,52 @@
       "dev": true
     },
     "nyc": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-7.1.0.tgz",
-      "integrity": "sha1-jhSXHzoV0au+x6xhDvVMuInp/7Q=",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+      "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
       "dev": true,
       "requires": {
+        "archy": "^1.0.0",
         "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.3.0",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^1.1.2",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.3",
-        "istanbul-lib-coverage": "^1.0.0-alpha.4",
-        "istanbul-lib-hook": "^1.0.0-alpha.4",
-        "istanbul-lib-instrument": "^1.1.0-alpha.3",
-        "istanbul-lib-report": "^1.0.0-alpha.3",
-        "istanbul-lib-source-maps": "^1.0.0-alpha.10",
-        "istanbul-reports": "^1.0.0-alpha.8",
-        "md5-hex": "^1.2.0",
-        "micromatch": "^2.3.11",
-        "mkdirp": "^0.5.0",
-        "pkg-up": "^1.0.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.4",
-        "signal-exit": "^3.0.0",
-        "spawn-wrap": "^1.2.4",
-        "test-exclude": "^1.1.0",
-        "yargs": "^4.8.1",
-        "yargs-parser": "^2.4.1"
+        "caching-transform": "^3.0.1",
+        "convert-source-map": "^1.6.0",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.1.0",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.1",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.1.0",
+        "uuid": "^3.3.2",
+        "yargs": "^12.0.5",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "ansi-regex": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "append-transform": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1"
+            "default-require-extensions": "^2.0.0"
           }
         },
-        "arr-flatten": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
+        "archy": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -4409,192 +4625,63 @@
           "dev": true
         },
         "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.11.0",
+          "version": "2.6.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.0.0",
-            "chalk": "^1.1.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^2.0.0"
-          }
-        },
-        "babel-generator": {
-          "version": "6.11.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-messages": "^6.8.0",
-            "babel-runtime": "^6.9.0",
-            "babel-types": "^6.10.2",
-            "detect-indent": "^3.0.1",
-            "lodash": "^4.2.0",
-            "source-map": "^0.5.0"
-          }
-        },
-        "babel-messages": {
-          "version": "6.8.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.0.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.9.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.9.5"
-          }
-        },
-        "babel-template": {
-          "version": "6.9.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.9.0",
-            "babel-traverse": "^6.9.0",
-            "babel-types": "^6.9.0",
-            "babylon": "^6.7.0",
-            "lodash": "^4.2.0"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.11.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.8.0",
-            "babel-messages": "^6.8.0",
-            "babel-runtime": "^6.9.0",
-            "babel-types": "^6.9.0",
-            "babylon": "^6.7.0",
-            "debug": "^2.2.0",
-            "globals": "^8.3.0",
-            "invariant": "^2.2.0",
-            "lodash": "^4.2.0"
-          }
-        },
-        "babel-types": {
-          "version": "6.11.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.9.1",
-            "babel-traverse": "^6.9.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.2.0",
-            "to-fast-properties": "^1.0.1"
-          }
-        },
-        "babylon": {
-          "version": "6.8.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.0.0"
+            "lodash": "^4.17.11"
           }
         },
         "balanced-match": {
-          "version": "0.4.2",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.6",
+          "version": "1.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^0.4.1",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
         "caching-transform": {
-          "version": "1.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "hasha": "^3.0.0",
+            "make-dir": "^1.3.0",
+            "package-hash": "^3.0.0",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "camelcase": {
-          "version": "1.2.1",
+          "version": "5.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
+          "dev": true
         },
         "cliui": {
-          "version": "2.1.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
-          "version": "1.0.0",
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commander": {
+          "version": "2.17.1",
           "bundled": true,
           "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+          "optional": true
         },
         "commondir": {
           "version": "1.0.1",
@@ -4607,17 +4694,15 @@
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.3.0",
+          "version": "1.6.0",
           "bundled": true,
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.4.1",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         },
         "cross-spawn": {
-          "version": "4.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4626,11 +4711,11 @@
           }
         },
         "debug": {
-          "version": "2.2.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
+            "ms": "^2.1.1"
           }
         },
         "decamelize": {
@@ -4639,123 +4724,82 @@
           "dev": true
         },
         "default-require-extensions": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "^3.0.0"
           }
         },
-        "detect-indent": {
-          "version": "3.0.1",
+        "end-of-stream": {
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "get-stdin": "^4.0.1",
-            "minimist": "^1.1.0",
-            "repeating": "^1.1.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "once": "^1.4.0"
           }
         },
         "error-ex": {
-          "version": "1.3.0",
+          "version": "1.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
+        "es6-error": {
+          "version": "4.1.1",
           "bundled": true,
           "dev": true
         },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
+        "execa": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fill-range": "^2.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
           }
         },
         "find-cache-dir": {
-          "version": "0.1.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "find-up": {
-          "version": "1.1.2",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^0.1.5"
+            "locate-path": "^3.0.0"
           }
         },
         "foreground-child": {
-          "version": "1.5.3",
+          "version": "1.5.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4769,91 +4813,69 @@
           "dev": true
         },
         "get-caller-file": {
-          "version": "1.0.1",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
-        "get-stdin": {
-          "version": "4.0.1",
+        "get-stream": {
+          "version": "4.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "glob": {
-          "version": "7.0.5",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "globals": {
-          "version": "8.18.0",
-          "bundled": true,
-          "dev": true
-        },
         "graceful-fs": {
-          "version": "4.1.4",
+          "version": "4.1.15",
           "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.5",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
+            "async": "^2.5.0",
             "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.4.4",
+              "version": "0.6.1",
               "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
+              "dev": true
             }
           }
         },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
         "has-flag": {
-          "version": "1.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
+        "hasha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-stream": "^1.0.1"
+          }
+        },
         "hosted-git-info": {
-          "version": "2.1.5",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true
         },
@@ -4863,7 +4885,7 @@
           "dev": true
         },
         "inflight": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -4872,20 +4894,12 @@
           }
         },
         "inherits": {
-          "version": "2.0.1",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
         },
-        "invariant": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        },
         "invert-kv": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
@@ -4894,310 +4908,189 @@
           "bundled": true,
           "dev": true
         },
-        "is-buffer": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-primitive": "^2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-primitive": {
           "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
+        "is-stream": {
+          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
         "isexe": {
-          "version": "1.1.2",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
         },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
         "istanbul-lib-coverage": {
-          "version": "1.0.0-alpha.4",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.0.0-alpha.4",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "^0.3.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.1.0-alpha.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "babel-generator": "^6.11.3",
-            "babel-template": "^6.9.0",
-            "babel-traverse": "^6.9.0",
-            "babel-types": "^6.10.2",
-            "babylon": "^6.8.1",
-            "istanbul-lib-coverage": "^1.0.0-alpha.4"
+            "append-transform": "^1.0.0"
           }
         },
         "istanbul-lib-report": {
-          "version": "1.0.0-alpha.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.2",
-            "istanbul-lib-coverage": "^1.0.0-alpha",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "rimraf": "^2.4.3",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "supports-color": "^6.0.0"
           },
           "dependencies": {
             "supports-color": {
-              "version": "3.1.2",
+              "version": "6.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.0.0-alpha.10",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.0.0-alpha.0",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.4.4",
-            "source-map": "^0.5.3"
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.0.0-alpha.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "js-tokens": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.assign": {
-          "version": "4.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lodash.keys": "^4.0.0",
-            "lodash.rest": "^4.0.0"
-          }
-        },
-        "lodash.keys": {
-          "version": "4.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "lodash.rest": {
-          "version": "4.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "js-tokens": "^1.0.1"
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
           },
           "dependencies": {
-            "js-tokens": {
-              "version": "1.0.3",
+            "source-map": {
+              "version": "0.6.1",
               "bundled": true,
               "dev": true
             }
           }
         },
-        "lru-cache": {
-          "version": "4.0.1",
+        "istanbul-reports": {
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.1",
-            "yallist": "^2.0.0"
+            "handlebars": "^4.1.0"
           }
         },
-        "md5-hex": {
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "pify": "^3.0.0"
           }
         },
-        "md5-o-matic": {
-          "version": "0.1.1",
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
           "bundled": true,
           "dev": true
         },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
         "minimatch": {
-          "version": "3.0.2",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.0.0"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "0.0.10",
           "bundled": true,
           "dev": true
         },
@@ -5207,45 +5100,51 @@
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "ms": {
-          "version": "0.7.1",
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
           "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.3.5",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "normalize-path": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "number-is-nan": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "object.omit": {
-          "version": "2.0.0",
+        "npm-run-path": {
+          "version": "2.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "for-own": "^0.1.3",
-            "is-extendable": "^0.1.1"
+            "path-key": "^2.0.0"
           }
         },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
         "once": {
-          "version": "1.3.3",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5262,167 +5161,156 @@
           }
         },
         "os-homedir": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
         "os-locale": {
-          "version": "1.4.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
         },
-        "parse-glob": {
-          "version": "3.0.4",
+        "p-defer": {
+          "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
-          }
+          "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
+        "p-finally": {
+          "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
+          "dev": true
         },
-        "path-exists": {
+        "p-is-promise": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "p-try": "^2.0.0"
           }
         },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
+            "lodash.flattendeep": "^4.4.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "path-is-absolute": {
-          "version": "1.0.0",
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
         "path-parse": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true
         },
         "path-type": {
-          "version": "1.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
-          "version": "2.3.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
         },
         "pkg-dir": {
-          "version": "1.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "^3.0.0"
           }
-        },
-        "pkg-up": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "^1.0.0"
-          }
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "randomatic": {
-          "version": "1.1.5",
+        "pump": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^2.0.2",
-            "kind-of": "^3.0.2"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "read-pkg": {
-          "version": "1.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
+            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
-        "regenerator-runtime": {
-          "version": "0.9.5",
-          "bundled": true,
-          "dev": true
-        },
-        "regex-cache": {
-          "version": "0.4.3",
+        "release-zalgo": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "^0.1.3",
-            "is-primitive": "^2.0.0"
-          }
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.5.4",
-          "bundled": true,
-          "dev": true
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
+            "es6-error": "^4.0.1"
           }
         },
         "require-directory": {
@@ -5435,30 +5323,34 @@
           "bundled": true,
           "dev": true
         },
+        "resolve": {
+          "version": "1.10.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "resolve-from": {
-          "version": "2.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
-        "right-align": {
-          "version": "0.1.3",
+        "rimraf": {
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "align-text": "^0.1.1"
+            "glob": "^7.1.3"
           }
         },
-        "rimraf": {
-          "version": "2.5.4",
+        "safe-buffer": {
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
+          "dev": true
         },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true
         },
@@ -5467,181 +5359,147 @@
           "bundled": true,
           "dev": true
         },
-        "signal-exit": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.2.4",
+        "shebang-command": {
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "foreground-child": "^1.3.3",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.3.3",
-            "signal-exit": "^2.0.0",
-            "which": "^1.2.4"
-          },
-          "dependencies": {
-            "signal-exit": {
-              "version": "2.1.2",
-              "bundled": true,
-              "dev": true
-            }
+            "shebang-regex": "^1.0.0"
           }
         },
-        "spdx-correct": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-license-ids": "^1.0.2"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "^1.0.4",
-            "spdx-license-ids": "^1.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "string-width": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "lodash.assign": "^4.0.9",
-            "micromatch": "^2.3.8",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
-          }
-        },
-        "to-fast-properties": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.7.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "~0.2.6",
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
-          },
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "~1.0.0",
-            "spdx-expression-parse": "~1.0.0"
-          }
-        },
-        "which": {
-          "version": "1.2.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "^1.1.1"
-          }
-        },
-        "which-module": {
+        "shebang-regex": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "window-size": {
-          "version": "0.1.0",
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "5.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "3.4.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -5649,11 +5507,45 @@
           "dev": true
         },
         "wrap-ansi": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
           }
         },
         "wrappy": {
@@ -5662,77 +5554,51 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "1.1.4",
+          "version": "2.4.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "signal-exit": "^3.0.2"
           }
         },
         "y18n": {
-          "version": "3.2.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
         "yallist": {
-          "version": "2.0.0",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true
         },
         "yargs": {
-          "version": "4.8.1",
+          "version": "12.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
-          },
-          "dependencies": {
-            "cliui": {
-              "version": "3.2.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "window-size": {
-              "version": "0.2.0",
-              "bundled": true,
-              "dev": true
-            }
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "2.4.1",
+          "version": "11.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
   "homepage": "https://github.com/mapbox/cloudfriend#readme",
   "devDependencies": {
     "@mapbox/eslint-config-mapbox": "^1.2.1",
+    "cfn-response": "^1.0.1",
     "documentation": "^8.0.2",
     "eslint": "^3.2.0",
     "eslint-plugin-node": "^6.0.1",
-    "nyc": "^7.1.0",
+    "nyc": "^13.3.0",
     "opener": "^1.4.1",
     "tape": "^4.6.0"
   },

--- a/test/fixtures/shortcuts/hookshot-load-balancer.json
+++ b/test/fixtures/shortcuts/hookshot-load-balancer.json
@@ -1,0 +1,491 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Metadata": {},
+  "Parameters": {},
+  "Mappings": {},
+  "Conditions": {},
+  "Resources": {
+    "HookshotLoadBalancer": {
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "Properties": {
+        "IpAddressType": "ipv4",
+        "Name": {
+          "Fn::Sub": [
+            "${AWS::StackName}-${prefix}",
+            {
+              "prefix": "hookshot"
+            }
+          ]
+        },
+        "Scheme": "internet-facing",
+        "SecurityGroups": [
+          "sg-123"
+        ],
+        "Subnets": [
+          "subnet-123"
+        ],
+        "Type": "application"
+      }
+    },
+    "HookshotTargetGroup": {
+      "Type": "AWS::CloudFormation::CustomResource",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroupCustomResource",
+            "Arn"
+          ]
+        },
+        "Name": {
+          "Fn::Sub": [
+            "${AWS::StackName}-${prefix}",
+            {
+              "prefix": "hookshot"
+            }
+          ]
+        },
+        "HealthCheckPath": "/status"
+      }
+    },
+    "HookshotInvocationPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "Destination",
+            "Arn"
+          ]
+        },
+        "Principal": "elasticloadbalancing.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroup",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "HookshotTargetGroupRegistration": {
+      "Type": "AWS::CloudFormation::CustomResource",
+      "DependsOn": "HookshotInvocationPermission",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroupRegistrationCustomResource",
+            "Arn"
+          ]
+        },
+        "TargetGroupArn": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroup",
+            "Arn"
+          ]
+        },
+        "LambdaFunctionArn": {
+          "Fn::GetAtt": [
+            "Destination",
+            "Arn"
+          ]
+        }
+      }
+    },
+    "HookshotTargetGroupCustomResourceLogs": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "/aws/lambda/${name}",
+            {
+              "name": {
+                "Fn::Sub": [
+                  "${AWS::StackName}-${prefix}-target-group-custom-resource",
+                  {
+                    "prefix": "hookshot"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "RetentionInDays": 14
+      }
+    },
+    "HookshotTargetGroupCustomResourceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "main",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "logs:*",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "HookshotTargetGroupCustomResourceLogs",
+                      "Arn"
+                    ]
+                  }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "elasticloadbalancing:CreateTargetGroup",
+                    "elasticloadbalancing:DeleteTargetGroup",
+                    "elasticloadbalancing:ModifyTargetGroup",
+                    "elasticloadbalancing:ModifyTargetGroupAttributes"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "HookshotTargetGroupCustomResource": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "module.exports.handler = function targetGroup(event,context){cov_1l8mhrhdzc.f[9]++;const response=(cov_1l8mhrhdzc.s[55]++,require('cfn-response'));const AWS=(cov_1l8mhrhdzc.s[56]++,require('aws-sdk'));const elb=(cov_1l8mhrhdzc.s[57]++,new AWS.ELBv2());cov_1l8mhrhdzc.s[58]++;const main=async()=>{cov_1l8mhrhdzc.f[10]++;const{RequestType,PhysicalResourceId,ResourceProperties}=(cov_1l8mhrhdzc.s[59]++,event);cov_1l8mhrhdzc.s[60]++;if(RequestType.toUpperCase()==='CREATE'){cov_1l8mhrhdzc.b[31][0]++;const{TargetGroups}=(cov_1l8mhrhdzc.s[61]++,await elb.createTargetGroup({Name:ResourceProperties.Name,HealthCheckIntervalSeconds:30,HealthCheckPath:ResourceProperties.HealthCheckPath,HealthCheckTimeoutSeconds:5,HealthyThresholdCount:3,UnhealthyThresholdCount:3,TargetType:'lambda'}).promise());const data=(cov_1l8mhrhdzc.s[62]++,{Arn:TargetGroups[0].TargetGroupArn});cov_1l8mhrhdzc.s[63]++;const cleanup=()=>{cov_1l8mhrhdzc.f[11]++;cov_1l8mhrhdzc.s[64]++;return elb.deleteTargetGroup({TargetGroupArn:data.Arn}).promise();};cov_1l8mhrhdzc.s[65]++;await elb.modifyTargetGroupAttributes({TargetGroupArn:data.Arn,Attributes:[{Key:'lambda.multi_value_headers.enabled',Value:'true'}]}).promise().catch(async err=>{cov_1l8mhrhdzc.f[12]++;cov_1l8mhrhdzc.s[66]++;await cleanup();cov_1l8mhrhdzc.s[67]++;throw err;});cov_1l8mhrhdzc.s[68]++;response.send(event,context,response.SUCCESS,data,data.Arn);}else{cov_1l8mhrhdzc.b[31][1]++;}cov_1l8mhrhdzc.s[69]++;if(RequestType.toUpperCase()==='UPDATE'){cov_1l8mhrhdzc.b[32][0]++;cov_1l8mhrhdzc.s[70]++;response.send(event,context,response.SUCCESS);}else{cov_1l8mhrhdzc.b[32][1]++;}cov_1l8mhrhdzc.s[71]++;if(RequestType.toUpperCase()==='DELETE'){cov_1l8mhrhdzc.b[33][0]++;cov_1l8mhrhdzc.s[72]++;if(PhysicalResourceId){cov_1l8mhrhdzc.b[34][0]++;cov_1l8mhrhdzc.s[73]++;await elb.deleteTargetGroup({TargetGroupArn:PhysicalResourceId}).promise();}else{cov_1l8mhrhdzc.b[34][1]++;}cov_1l8mhrhdzc.s[74]++;response.send(event,context,response.SUCCESS);}else{cov_1l8mhrhdzc.b[33][1]++;}};cov_1l8mhrhdzc.s[75]++;main().catch(err=>{cov_1l8mhrhdzc.f[13]++;cov_1l8mhrhdzc.s[76]++;console.log(err);cov_1l8mhrhdzc.s[77]++;response.send(event,context,response.FAILED);});};"
+        },
+        "Description": {
+          "Fn::Sub": "HookshotTargetGroupCustomResource in the ${AWS::StackName} stack"
+        },
+        "FunctionName": {
+          "Fn::Sub": [
+            "${AWS::StackName}-${prefix}-target-group-custom-resource",
+            {
+              "prefix": "hookshot"
+            }
+          ]
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroupCustomResourceRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs8.10",
+        "Timeout": 300
+      }
+    },
+    "HookshotTargetGroupCustomResourceErrorAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": {
+          "Fn::Sub": "${AWS::StackName}-HookshotTargetGroupCustomResource-Errors-${AWS::Region}"
+        },
+        "AlarmDescription": {
+          "Fn::Sub": [
+            "Error alarm for ${name} lambda function in ${AWS::StackName} stack",
+            {
+              "name": {
+                "Fn::Sub": [
+                  "${AWS::StackName}-${prefix}-target-group-custom-resource",
+                  {
+                    "prefix": "hookshot"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "AlarmActions": [],
+        "Period": 60,
+        "EvaluationPeriods": 1,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/Lambda",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "HookshotTargetGroupCustomResource"
+            }
+          }
+        ],
+        "MetricName": "Errors"
+      }
+    },
+    "HookshotTargetGroupRegistrationCustomResourceLogs": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "/aws/lambda/${name}",
+            {
+              "name": {
+                "Fn::Sub": [
+                  "${AWS::StackName}-${prefix}-target-group-registration-custom-resource",
+                  {
+                    "prefix": "hookshot"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "RetentionInDays": 14
+      }
+    },
+    "HookshotTargetGroupRegistrationCustomResourceRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "main",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "logs:*",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "HookshotTargetGroupRegistrationCustomResourceLogs",
+                      "Arn"
+                    ]
+                  }
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": "elasticloadbalancing:RegisterTargets",
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "HookshotTargetGroupRegistrationCustomResource": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "module.exports.handler = function targetGroupRegistration(event,context){cov_1l8mhrhdzc.f[14]++;const response=(cov_1l8mhrhdzc.s[78]++,require('cfn-response'));const AWS=(cov_1l8mhrhdzc.s[79]++,require('aws-sdk'));const elb=(cov_1l8mhrhdzc.s[80]++,new AWS.ELBv2());const{RequestType,ResourceProperties}=(cov_1l8mhrhdzc.s[81]++,event);cov_1l8mhrhdzc.s[82]++;const main=async()=>{cov_1l8mhrhdzc.f[15]++;cov_1l8mhrhdzc.s[83]++;if(RequestType.toUpperCase()==='CREATE'){cov_1l8mhrhdzc.b[35][0]++;cov_1l8mhrhdzc.s[84]++;await elb.registerTargets({TargetGroupArn:ResourceProperties.TargetGroupArn,Targets:[{Id:ResourceProperties.LambdaFunctionArn}]}).promise();cov_1l8mhrhdzc.s[85]++;response.send(event,context,response.SUCCESS);}else{cov_1l8mhrhdzc.b[35][1]++;}cov_1l8mhrhdzc.s[86]++;if(RequestType.toUpperCase()==='UPDATE'){cov_1l8mhrhdzc.b[36][0]++;cov_1l8mhrhdzc.s[87]++;response.send(event,context,response.SUCCESS);}else{cov_1l8mhrhdzc.b[36][1]++;}cov_1l8mhrhdzc.s[88]++;if(RequestType.toUpperCase()==='DELETE'){cov_1l8mhrhdzc.b[37][0]++;cov_1l8mhrhdzc.s[89]++;response.send(event,context,response.SUCCESS);}else{cov_1l8mhrhdzc.b[37][1]++;}};cov_1l8mhrhdzc.s[90]++;main().catch(err=>{cov_1l8mhrhdzc.f[16]++;cov_1l8mhrhdzc.s[91]++;console.log(err);cov_1l8mhrhdzc.s[92]++;response.send(event,context,response.FAILED);});};"
+        },
+        "Description": {
+          "Fn::Sub": "HookshotTargetGroupRegistrationCustomResource in the ${AWS::StackName} stack"
+        },
+        "FunctionName": {
+          "Fn::Sub": [
+            "${AWS::StackName}-${prefix}-target-group-registration-custom-resource",
+            {
+              "prefix": "hookshot"
+            }
+          ]
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "HookshotTargetGroupRegistrationCustomResourceRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs8.10",
+        "Timeout": 300
+      }
+    },
+    "HookshotTargetGroupRegistrationCustomResourceErrorAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": {
+          "Fn::Sub": "${AWS::StackName}-HookshotTargetGroupRegistrationCustomResource-Errors-${AWS::Region}"
+        },
+        "AlarmDescription": {
+          "Fn::Sub": [
+            "Error alarm for ${name} lambda function in ${AWS::StackName} stack",
+            {
+              "name": {
+                "Fn::Sub": [
+                  "${AWS::StackName}-${prefix}-target-group-registration-custom-resource",
+                  {
+                    "prefix": "hookshot"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "AlarmActions": [],
+        "Period": 60,
+        "EvaluationPeriods": 1,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/Lambda",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "HookshotTargetGroupRegistrationCustomResource"
+            }
+          }
+        ],
+        "MetricName": "Errors"
+      }
+    },
+    "HookshotHttpListener": {
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
+      "Properties": {
+        "DefaultActions": [
+          {
+            "TargetGroupArn": {
+              "Fn::GetAtt": [
+                "HookshotTargetGroup",
+                "Arn"
+              ]
+            },
+            "Type": "forward"
+          }
+        ],
+        "LoadBalancerArn": {
+          "Ref": "HookshotLoadBalancer"
+        },
+        "Port": 80,
+        "Protocol": "HTTP"
+      }
+    },
+    "DestinationLogs": {
+      "Type": "AWS::Logs::LogGroup",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Sub": [
+            "/aws/lambda/${name}",
+            {
+              "name": {
+                "Fn::Sub": "${AWS::StackName}-Destination"
+              }
+            }
+          ]
+        },
+        "RetentionInDays": 14
+      }
+    },
+    "DestinationRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Principal": {
+                "Service": "lambda.amazonaws.com"
+              }
+            }
+          ]
+        },
+        "Policies": [
+          {
+            "PolicyName": "main",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": "logs:*",
+                  "Resource": {
+                    "Fn::GetAtt": [
+                      "DestinationLogs",
+                      "Arn"
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "Destination": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "ZipFile": "module.exports.handler = (e, c, cb) => cb();"
+        },
+        "Description": {
+          "Fn::Sub": "Destination in the ${AWS::StackName} stack"
+        },
+        "FunctionName": {
+          "Fn::Sub": "${AWS::StackName}-Destination"
+        },
+        "Handler": "index.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "DestinationRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs8.10",
+        "Timeout": 300
+      }
+    },
+    "DestinationErrorAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmName": {
+          "Fn::Sub": "${AWS::StackName}-Destination-Errors-${AWS::Region}"
+        },
+        "AlarmDescription": {
+          "Fn::Sub": [
+            "Error alarm for ${name} lambda function in ${AWS::StackName} stack",
+            {
+              "name": {
+                "Fn::Sub": "${AWS::StackName}-Destination"
+              }
+            }
+          ]
+        },
+        "AlarmActions": [],
+        "Period": 60,
+        "EvaluationPeriods": 1,
+        "Statistic": "Sum",
+        "Threshold": 0,
+        "ComparisonOperator": "GreaterThanThreshold",
+        "TreatMissingData": "notBreaching",
+        "Namespace": "AWS/Lambda",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "Destination"
+            }
+          }
+        ],
+        "MetricName": "Errors"
+      }
+    }
+  },
+  "Outputs": {}
+}

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -562,3 +562,34 @@ test('[shortcuts] hookshot github', (assert) => {
 
   assert.end();
 });
+
+test('[shortcuts] hookshot load-balancer', (assert) => {
+  // assert.throws(
+  //   () => new cf.shortcuts.hookshot.LoadBalancer(),
+  //   /You must provide a Prefix, and PassthroughTo/,
+  //   'throws without required parameters'
+  // );
+
+  const to = new cf.shortcuts.Lambda({
+    LogicalName: 'Destination',
+    Code: {
+      ZipFile: 'module.exports.handler = (e, c, cb) => cb();'
+    }
+  });
+
+  const github = new cf.shortcuts.hookshot.LoadBalancer({
+    PassthroughTo: 'Destination',
+    SecurityGroups: ['sg-123'],
+    Subnets: ['subnet-123']
+  });
+
+  const template = cf.merge(github, to);
+  if (update) fixtures.update('hookshot-load-balancer', template);
+  assert.deepEqual(
+    normalizeDeployment(noUndefined(template)),
+    normalizeDeployment(fixtures.get('hookshot-load-balancer')),
+    'expected resources generated with defaults'
+  );
+
+  assert.end();
+});


### PR DESCRIPTION
This PR introduces `new cf.shortcuts.hoookshot.LoadBalancer()`, which is intended to operate similarly to the other hookshots, but use a Lambda-backed application load-balancer instead of an API Gateway.

In many cases API Gateway is overkill, or otherwise more confusing than its worth. 