### PR TITLE
Do not use AWS::URLSuffix for some services

### DIFF
--- a/lib/shortcuts/service-role.js
+++ b/lib/shortcuts/service-role.js
@@ -59,19 +59,20 @@ class ServiceRole {
       throw new Error('You must provide a LogicalName and Service');
 
     const avoidSuffix = [
-      'swf',
       'apigateway',
-      'elasticbeanstalk',
+      'autoscaling',
       'cloudformation',
+      'codedeploy',
+      'ecs-tasks',
+      'elasticbeanstalk',
       'iot',
-      'storagegateway',
+      'lambda',
       'rds',
       'redshift',
       's3',
       'sms',
-      'codedeploy',
-      'autoscaling',
-      'lambda'
+      'storagegateway',
+      'swf'
     ];
 
     const prefix = Service.replace(/\.amazonaws.com(\..*)?$/, '');

--- a/lib/shortcuts/service-role.js
+++ b/lib/shortcuts/service-role.js
@@ -58,8 +58,29 @@ class ServiceRole {
     if (required.some((variable) => !variable))
       throw new Error('You must provide a LogicalName and Service');
 
+    const avoidSuffix = [
+      'swf',
+      'apigateway',
+      'elasticbeanstalk',
+      'cloudformation',
+      'iot',
+      'storagegateway',
+      'rds',
+      'redshift',
+      's3',
+      'sms',
+      'codedeploy',
+      'autoscaling',
+      'lambda'
+    ];
+
+    const prefix = Service.replace(/\.amazonaws.com(\..*)?$/, '');
+
+
     Service = {
-      'Fn::Sub': `${Service.replace(/\.amazonaws.com(\..*)?$/, '')}.\${AWS::URLSuffix}`
+      'Fn::Sub': avoidSuffix.includes(prefix)
+        ? `${prefix}.amazonaws.com`
+        : `${prefix}.\${AWS::URLSuffix}`
     };
 
     this.Resources = {

--- a/test/fixtures/shortcuts/service-role-no-defaults.json
+++ b/test/fixtures/shortcuts/service-role-no-defaults.json
@@ -33,7 +33,7 @@
               "Action": "sts:AssumeRole",
               "Principal": {
                 "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
+                  "Fn::Sub": "lambda.amazonaws.com"
                 }
               }
             }

--- a/test/fixtures/shortcuts/service-role-no-url-suffix.json
+++ b/test/fixtures/shortcuts/service-role-no-url-suffix.json
@@ -15,7 +15,7 @@
               "Action": "sts:AssumeRole",
               "Principal": {
                 "Service": {
-                  "Fn::Sub": "lambda.${AWS::URLSuffix}"
+                  "Fn::Sub": "lambda.amazonaws.com"
                 }
               }
             }

--- a/test/fixtures/shortcuts/service-role-url-suffix-with-replacement.json
+++ b/test/fixtures/shortcuts/service-role-url-suffix-with-replacement.json
@@ -15,7 +15,7 @@
               "Action": "sts:AssumeRole",
               "Principal": {
                 "Service": {
-                  "Fn::Sub": "lambda.amazonaws.com"
+                  "Fn::Sub": "ec2.${AWS::URLSuffix}"
                 }
               }
             }

--- a/test/fixtures/shortcuts/service-role-url-suffix.json
+++ b/test/fixtures/shortcuts/service-role-url-suffix.json
@@ -15,7 +15,7 @@
               "Action": "sts:AssumeRole",
               "Principal": {
                 "Service": {
-                  "Fn::Sub": "lambda.amazonaws.com"
+                  "Fn::Sub": "ec2.${AWS::URLSuffix}"
                 }
               }
             }

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -343,11 +343,37 @@ test('[shortcuts] service role', (assert) => {
   });
 
   template = cf.merge(role);
-  if (update) fixtures.update('service-role-suffix-replace', template);
+  if (update) fixtures.update('service-role-no-url-suffix', template);
   assert.deepEqual(
     noUndefined(template),
-    fixtures.get('service-role-suffix-replace'),
-    'expected resources generated, region-specific service suffix replaced'
+    fixtures.get('service-role-no-url-suffix'),
+    'expected resources generated, service for which AWS::URLSuffix is invalid'
+  );
+
+  role = new cf.shortcuts.ServiceRole({
+    LogicalName: 'MyRole',
+    Service: 'ec2'
+  });
+
+  template = cf.merge(role);
+  if (update) fixtures.update('service-role-url-suffix', template);
+  assert.deepEqual(
+    noUndefined(template),
+    fixtures.get('service-role-url-suffix'),
+    'expected resources generated, service for which AWS::URLSuffix is invalid'
+  );
+
+  role = new cf.shortcuts.ServiceRole({
+    LogicalName: 'MyRole',
+    Service: 'ec2.amazonaws.com'
+  });
+
+  template = cf.merge(role);
+  if (update) fixtures.update('service-role-url-suffix-with-replacement', template);
+  assert.deepEqual(
+    noUndefined(template),
+    fixtures.get('service-role-url-suffix-with-replacement'),
+    'expected resources generated, service for which AWS::URLSuffix is invalid specified with a suffix'
   );
 
   role = new cf.shortcuts.ServiceRole({


### PR DESCRIPTION
The cloudformation pseudo parameter `AWS::URLSuffix` resolves to:

- `amazonaws.com.cn` in China regions
- `amazonaws.com` everywhere else

However, from the perspective of creating IAM roles, some AWS services in China regions use `.com.cn`, and some do not. This is not documented well (or maybe at all).

This PR calls out a set of known service where using `AWS::URLSuffix` in a China region would result in an invalid service URL. 

fixes #56 