### PR TITLE
Firehose doesn't have .cn

### DIFF
--- a/lib/shortcuts/service-role.js
+++ b/lib/shortcuts/service-role.js
@@ -65,6 +65,7 @@ class ServiceRole {
       'codedeploy',
       'ecs-tasks',
       'elasticbeanstalk',
+      'firehose',
       'iot',
       'lambda',
       'rds',


### PR DESCRIPTION
... adds another caveat to the URL suffix for services that don't use `.cn` in China.