### PR TITLE
Make hookshot api-gateways regional

### DIFF
--- a/lib/shortcuts/hookshot.js
+++ b/lib/shortcuts/hookshot.js
@@ -111,7 +111,10 @@ class Passthrough {
         Type: 'AWS::ApiGateway::RestApi',
         Properties: {
           Name: { 'Fn::Sub': '${AWS::StackName}-webhook' },
-          FailOnWarnings: true
+          FailOnWarnings: true,
+          EndpointConfiguration: {
+            Types: ['REGIONAL']
+          }
         }
       },
 

--- a/test/fixtures/shortcuts/hookshot-github-secret-ref.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-ref.json
@@ -15,14 +15,19 @@
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment55cc8548"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -41,7 +46,7 @@
         ]
       }
     },
-    "PassDeployment55cc8548": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-github-secret-string.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-string.json
@@ -11,14 +11,19 @@
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment55cc8548"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -37,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment55cc8548": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -11,14 +11,19 @@
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment55cc8548"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -37,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment55cc8548": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -52,7 +51,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -130,6 +129,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassAccessLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -121,6 +120,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassFunctionLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -121,6 +120,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassFunctionLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -121,6 +120,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassFunctionLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-logging.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -121,6 +120,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassFunctionLogs": {

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -5,26 +5,25 @@
   "Mappings": {},
   "Conditions": {},
   "Resources": {
-    "PassSecret": {
-      "Type": "AWS::ApiGateway::ApiKey",
-      "Properties": {
-        "Enabled": false
-      }
-    },
     "PassApi": {
       "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Name": {
           "Fn::Sub": "${AWS::StackName}-webhook"
         },
-        "FailOnWarnings": true
+        "FailOnWarnings": true,
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }
       }
     },
     "PassStage": {
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment60b3cb7b"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -43,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment60b3cb7b": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -121,6 +120,12 @@
         "SourceArn": {
           "Fn::Sub": "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${PassApi}/*"
         }
+      }
+    },
+    "PassSecret": {
+      "Type": "AWS::ApiGateway::ApiKey",
+      "Properties": {
+        "Enabled": false
       }
     },
     "PassFunctionLogs": {


### PR DESCRIPTION
Hookshot really doesn't benefit at all from an edge-optimized API gateway. There are no GETs!

This PR makes hookshot gateways regional. This also opens up [some multi-region redundancy options](https://aws.amazon.com/blogs/compute/building-a-multi-region-serverless-application-with-amazon-api-gateway-and-aws-lambda/) that cannot be achieved with an edge-optimized gateway.