### PR TITLE
Revert upgrading Lambda shortcuts to Node 10

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -54,7 +54,7 @@ LogGroup, a Role, an Alarm on function errors, and the Lambda Function itself.
     -   `options.Layers` **[Array][39]&lt;[String][31]>** See [AWS documentation][40] (optional, default `undefined`)
     -   `options.MemorySize` **[Number][41]** See [AWS documentation][42] (optional, default `128`)
     -   `options.ReservedConcurrentExecutions` **[Number][41]** See [AWS documentation][43] (optional, default `undefined`)
-    -   `options.Runtime` **[String][31]** See [AWS documentation][44] (optional, default `'node10.x'`)
+    -   `options.Runtime` **[String][31]** See [AWS documentation][44] (optional, default `'nodejs8.10'`)
     -   `options.Tags` **[Array][39]&lt;[Object][30]>** See [AWS documentation][45] (optional, default `undefined`)
     -   `options.Timeout` **[Number][41]** See [AWS documentation][46] (optional, default `300`)
     -   `options.TracingConfig` **[Object][30]** See [AWS documentation][47] (optional, default `undefined`)

--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -21,7 +21,7 @@
  * @param {Array<String>} [options.Layers=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-layers)
  * @param {Number} [options.MemorySize=128] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-memorysize)
  * @param {Number} [options.ReservedConcurrentExecutions=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-reservedconcurrentexecutions)
- * @param {String} [options.Runtime='node10.x'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)
+ * @param {String} [options.Runtime='nodejs8.10'] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-runtime)
  * @param {Array<Object>} [options.Tags=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-tags)
  * @param {Number} [options.Timeout=300] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-timeout)
  * @param {Object} [options.TracingConfig=undefined] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-tracingconfig)
@@ -76,7 +76,7 @@ class Lambda {
       Layers,
       MemorySize = 128,
       ReservedConcurrentExecutions,
-      Runtime = 'node10.x',
+      Runtime = 'nodejs8.10',
       Tags,
       Timeout = 300,
       TracingConfig,

--- a/test/fixtures/shortcuts/hookshot-github-secret-ref.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-ref.json
@@ -27,7 +27,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -46,7 +46,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -231,7 +231,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -341,7 +341,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-github-secret-string.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-string.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -225,7 +225,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -335,7 +335,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -233,7 +233,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -343,7 +343,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -51,7 +51,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -229,7 +229,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -339,7 +339,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -211,7 +211,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -323,7 +323,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -211,7 +211,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -321,7 +321,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -211,7 +211,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -321,7 +321,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-logging.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -211,7 +211,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -321,7 +321,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -23,7 +23,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment6a8e4c10"
+          "Ref": "PassDeployment28becc6f"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +42,7 @@
         ]
       }
     },
-    "PassDeployment6a8e4c10": {
+    "PassDeployment28becc6f": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {
@@ -211,7 +211,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 30
       }
     },
@@ -321,7 +321,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/lambda-defaults.json
+++ b/test/fixtures/shortcuts/lambda-defaults.json
@@ -77,7 +77,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/lambda-zipfile.json
+++ b/test/fixtures/shortcuts/lambda-zipfile.json
@@ -76,7 +76,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -97,7 +97,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/scheduled-lambda-defaults.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-defaults.json
@@ -77,7 +77,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/scheduled-lambda-full.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-full.json
@@ -77,7 +77,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },

--- a/test/fixtures/shortcuts/stream-lambda.json
+++ b/test/fixtures/shortcuts/stream-lambda.json
@@ -101,7 +101,7 @@
             "Arn"
           ]
         },
-        "Runtime": "node10.x",
+        "Runtime": "nodejs8.10",
         "Timeout": 300
       }
     },


### PR DESCRIPTION
This reverts commit 80860e13e67e924bf4686599107a928d1c379bea.

I guess Node 10 Lambdas do not support `ZipFile` yet. And hookshot's Lambda uses `ZipFile`.

> ZipFile can only be used when Runtime is set to either of nodejs, nodejs4.3, nodejs6.10, nodejs8.10, python2.7, python3.6, python3.7.

So I think we should play it safe and stick with Node 8.

@mapbox/platform for review, please.

cc @mapbox/accounts 