### PR TITLE
Fix api.md `EventLambda` headings

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -6,7 +6,7 @@
     -   [Parameters][2]
     -   [Properties][3]
     -   [Examples][4]
--   [EventLambda][5]
+-   [ScheduledLambda][5]
     -   [Parameters][6]
     -   [Examples][7]
 -   [EventLambda][8]
@@ -119,7 +119,7 @@ const lambda = new cf.shortcuts.Lambda({
 module.exports = cf.merge(myTemplate, lambda);
 ```
 
-## EventLambda
+## ScheduledLambda
 
 **Extends Lambda**
 
@@ -672,13 +672,13 @@ module.exports = cf.merge(myTemplate, webhook);
 
 [4]: #examples
 
-[5]: #eventlambda
+[5]: #scheduledlambda
 
 [6]: #parameters-1
 
 [7]: #examples-1
 
-[8]: #eventlambda-1
+[8]: #eventlambda
 
 [9]: #parameters-2
 

--- a/lib/shortcuts/scheduled-lambda.js
+++ b/lib/shortcuts/scheduled-lambda.js
@@ -35,7 +35,7 @@ const Lambda = require('./lambda');
  *
  * module.exports = cf.merge(myTemplate, lambda);
  */
-class EventLambda extends Lambda {
+class ScheduledLambda extends Lambda {
   constructor(options = {}) {
     super(options);
 
@@ -91,4 +91,4 @@ class EventLambda extends Lambda {
   }
 }
 
-module.exports = EventLambda;
+module.exports = ScheduledLambda;


### PR DESCRIPTION
The `ScheduledLambda` was mislabeled as a second `EventLambda` in api.md.

![image](https://user-images.githubusercontent.com/515424/65364599-b26d6780-dbc7-11e9-9403-78ee60c08dab.png)
