### PR TITLE
Fix queue shortcut bug

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Fix bug in queue shortcut
+
 # v3.8.0
 
 - Adds `ExistingTopicArn` option to queue shortcut

--- a/lib/shortcuts/queue.js
+++ b/lib/shortcuts/queue.js
@@ -128,7 +128,7 @@ class Queue {
       Type: 'AWS::SNS::Subscription',
       Properties: {
         Protocol: 'sqs',
-        ExistingTopicArn: subscribedExistingTopicArn,
+        TopicArn: subscribedExistingTopicArn,
         Endpoint: { 'Fn::GetAtt': [LogicalName, 'Arn'] }
       }
     };

--- a/test/fixtures/shortcuts/queue-defaults.json
+++ b/test/fixtures/shortcuts/queue-defaults.json
@@ -53,7 +53,7 @@
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
-        "ExistingTopicArn": { "Ref": "MyQueueTopic" },
+        "TopicArn": { "Ref": "MyQueueTopic" },
         "Endpoint": { "Fn::GetAtt": ["MyQueue", "Arn"]}
       }
     },

--- a/test/fixtures/shortcuts/queue-external-topic-ref.json
+++ b/test/fixtures/shortcuts/queue-external-topic-ref.json
@@ -48,7 +48,7 @@
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
-        "ExistingTopicArn": { "Ref": "TopicForOtherThing" },
+        "TopicArn": { "Ref": "TopicForOtherThing" },
         "Endpoint": { "Fn::GetAtt": ["MyQueue", "Arn"]}
       }
     },

--- a/test/fixtures/shortcuts/queue-external-topic.json
+++ b/test/fixtures/shortcuts/queue-external-topic.json
@@ -45,7 +45,7 @@
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
-        "ExistingTopicArn": "arn:aws:sns:us-east-1:111122223333:MyTopic",
+        "TopicArn": "arn:aws:sns:us-east-1:111122223333:MyTopic",
         "Endpoint": { "Fn::GetAtt": ["MyQueue", "Arn"]}
       }
     },

--- a/test/fixtures/shortcuts/queue-full.json
+++ b/test/fixtures/shortcuts/queue-full.json
@@ -68,7 +68,7 @@
       "Type": "AWS::SNS::Subscription",
       "Properties": {
         "Protocol": "sqs",
-        "ExistingTopicArn": { "Ref": "MyQueueTopic" },
+        "TopicArn": { "Ref": "MyQueueTopic" },
         "Endpoint": { "Fn::GetAtt": ["MyQueue", "Arn"]}
       }
     },


### PR DESCRIPTION
When I changed the parameter name in https://github.com/mapbox/cloudfriend/pull/78 after initial testing, I was too cavalier with find-and-replace and broke the subscription resource.

@rclark for review, please. I'll double-check this again with new stacks before deploying (which I should have done after the name change in the last PR).