### PR TITLE
scheduled lambdas shouldn't alarm while retries remain

### DIFF
--- a/lib/shortcuts/event-lambda.js
+++ b/lib/shortcuts/event-lambda.js
@@ -65,6 +65,10 @@ class EventLambda extends Lambda {
       }
     };
 
+    // Async lambdas will automatically retry three times with a retry delay of at least 1 min.
+    // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
+    this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
+
     this.Resources[`${this.LogicalName}Permission`] = {
       Type: 'AWS::Lambda::Permission',
       Condition: this.Condition,

--- a/lib/shortcuts/event-lambda.js
+++ b/lib/shortcuts/event-lambda.js
@@ -68,6 +68,7 @@ class EventLambda extends Lambda {
     // Async lambda executions will automatically retry three times with a retry delay of at least 1 min.
     // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
     this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
+    this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.TreatMissingData = 'missing';
 
     this.Resources[`${this.LogicalName}Permission`] = {
       Type: 'AWS::Lambda::Permission',

--- a/lib/shortcuts/event-lambda.js
+++ b/lib/shortcuts/event-lambda.js
@@ -65,7 +65,7 @@ class EventLambda extends Lambda {
       }
     };
 
-    // Async lambdas will automatically retry three times with a retry delay of at least 1 min.
+    // Async lambda executions will automatically retry three times with a retry delay of at least 1 min.
     // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
     this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
 

--- a/lib/shortcuts/scheduled-lambda.js
+++ b/lib/shortcuts/scheduled-lambda.js
@@ -75,6 +75,7 @@ class EventLambda extends Lambda {
     // Async lambda executions will automatically retry three times with a retry delay of at least 1 min.
     // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
     this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
+    this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.TreatMissingData = 'missing';
 
     this.Resources[`${this.LogicalName}Permission`] = {
       Type: 'AWS::Lambda::Permission',

--- a/lib/shortcuts/scheduled-lambda.js
+++ b/lib/shortcuts/scheduled-lambda.js
@@ -72,7 +72,7 @@ class EventLambda extends Lambda {
       }
     };
 
-    // Scheduled lambdas will automatically retry three times with a retry delay of at least 1 min.
+    // Async lambda executions will automatically retry three times with a retry delay of at least 1 min.
     // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
     this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
 

--- a/lib/shortcuts/scheduled-lambda.js
+++ b/lib/shortcuts/scheduled-lambda.js
@@ -72,6 +72,10 @@ class EventLambda extends Lambda {
       }
     };
 
+    // Scheduled lambdas will automatically retry three times with a retry delay of at least 1 min.
+    // https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html
+    this.Resources[`${this.LogicalName}ErrorAlarm`].Properties.DatapointsToAlarm = 3;
+
     this.Resources[`${this.LogicalName}Permission`] = {
       Type: 'AWS::Lambda::Permission',
       Condition: this.Condition,

--- a/test/fixtures/shortcuts/event-lambda-defaults.json
+++ b/test/fixtures/shortcuts/event-lambda-defaults.json
@@ -100,11 +100,11 @@
         "AlarmActions": [],
         "Period": 60,
         "EvaluationPeriods": 5,
-        "DatapointsToAlarm": 1,
+        "DatapointsToAlarm": 3,
         "Statistic": "Sum",
         "Threshold": 0,
         "ComparisonOperator": "GreaterThanThreshold",
-        "TreatMissingData": "notBreaching",
+        "TreatMissingData": "missing",
         "Namespace": "AWS/Lambda",
         "Dimensions": [
           {

--- a/test/fixtures/shortcuts/event-lambda-full.json
+++ b/test/fixtures/shortcuts/event-lambda-full.json
@@ -100,11 +100,11 @@
         "AlarmActions": [],
         "Period": 60,
         "EvaluationPeriods": 5,
-        "DatapointsToAlarm": 1,
+        "DatapointsToAlarm": 3,
         "Statistic": "Sum",
         "Threshold": 0,
         "ComparisonOperator": "GreaterThanThreshold",
-        "TreatMissingData": "notBreaching",
+        "TreatMissingData": "missing",
         "Namespace": "AWS/Lambda",
         "Dimensions": [
           {

--- a/test/fixtures/shortcuts/scheduled-lambda-defaults.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-defaults.json
@@ -100,11 +100,11 @@
         "AlarmActions": [],
         "Period": 60,
         "EvaluationPeriods": 5,
-        "DatapointsToAlarm": 1,
+        "DatapointsToAlarm": 3,
         "Statistic": "Sum",
         "Threshold": 0,
         "ComparisonOperator": "GreaterThanThreshold",
-        "TreatMissingData": "notBreaching",
+        "TreatMissingData": "missing",
         "Namespace": "AWS/Lambda",
         "Dimensions": [
           {

--- a/test/fixtures/shortcuts/scheduled-lambda-full.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-full.json
@@ -100,11 +100,11 @@
         "AlarmActions": [],
         "Period": 60,
         "EvaluationPeriods": 5,
-        "DatapointsToAlarm": 1,
+        "DatapointsToAlarm": 3,
         "Statistic": "Sum",
         "Threshold": 0,
         "ComparisonOperator": "GreaterThanThreshold",
-        "TreatMissingData": "notBreaching",
+        "TreatMissingData": "missing",
         "Namespace": "AWS/Lambda",
         "Dimensions": [
           {


### PR DESCRIPTION
proposal: An alarm should only go off if a scheduled lambda is in a terminal error state, that is, its retries are expired and there is no chance that the execution will succeed without manual intervention.

this PR increases the alarm threshold to 3 failure datapoints(periods), according to the aws docs this is the maximum amount of retries that will happen for a cloudwatch triggered lambda https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html.

cc @mapbox/platform 
