### PR TITLE
Correct the cron expression in ScheduledLambda example

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -151,7 +151,7 @@ const lambda = new cf.shortcuts.ScheduledLambda({
     S3Bucket: 'my-code-bucket',
     S3Key: 'path/to/code.zip'
   },
-  ScheduleExpression: 'cron(45 * * * *)',
+  ScheduleExpression: 'cron(45 * * * ? *)',
 });
 
 module.exports = cf.merge(myTemplate, lambda);

--- a/lib/shortcuts/scheduled-lambda.js
+++ b/lib/shortcuts/scheduled-lambda.js
@@ -24,7 +24,7 @@ const Lambda = require('./lambda');
  *     S3Bucket: 'my-code-bucket',
  *     S3Key: 'path/to/code.zip'
  *   },
- *   ScheduleExpression: 'cron(45 * * * *)',
+ *   ScheduleExpression: 'cron(45 * * * ? *)',
  * });
  *
  * module.exports = cf.merge(myTemplate, lambda);


### PR DESCRIPTION
I guess this resource has a more strict cron syntax than other things I've been using (like Airflow). Oops. Thought I'd correct that. Sorry @rclark.