### PR TITLE
Glue bugs: Fix capitalization and view schema

### DIFF
--- a/lib/shortcuts/glue-table.js
+++ b/lib/shortcuts/glue-table.js
@@ -31,7 +31,7 @@
  * @param {Object} [options.SerdeInfo={}] the serialization/deserialization information. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-serdeinfo)
  * @param {Object} [options.SkewedInfo=undefined] frequent value information. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-skewedinfo)
  * @param {Array<Object>} [options.SortColumns=undefined] list specifying the sort order. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-sortcolumns)
- * @param {Boolean} [options.StoredAsSubdirectories=true] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-storedasdubdirectories)
+ * @param {Boolean} [options.StoredAsSubDirectories=true] See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-storagedescriptor.html#cfn-glue-table-storagedescriptor-storedasdubdirectories)
  * @param {String} [options.Condition=undefined] if there is a Condition defined
  * in the template that should control whether or not to create this database,
  * specify the name of the condition here. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/conditions-section-structure.html)
@@ -79,7 +79,7 @@ class GlueTable {
       SerdeInfo = {},
       SkewedInfo,
       SortColumns,
-      StoredAsSubdirectories = true,
+      StoredAsSubDirectories = true,
       Condition,
       DependsOn
     } = options;
@@ -117,7 +117,7 @@ class GlueTable {
               SerdeInfo,
               SkewedInfo,
               SortColumns,
-              StoredAsSubdirectories
+              StoredAsSubDirectories
             }
           }
         }

--- a/lib/shortcuts/glue-view.js
+++ b/lib/shortcuts/glue-view.js
@@ -14,15 +14,14 @@ const GlueTable = require('./glue-table');
  */
 class GlueView extends GlueTable {
   constructor(options = {}) {
-    let { Parameters } = options;
+    let { Parameters, SqlVariables = {} } = options;
     const {
       Columns,
-      DatabaseName: schema,
-      OriginalSql: originalSql,
-      SqlVariables = {}
+      DatabaseName,
+      OriginalSql: originalSql
     } = options;
 
-    const required = [schema, Columns, originalSql];
+    const required = [DatabaseName, Columns, originalSql];
     if (required.some((variable) => !variable))
       throw new Error(
         'You must provide a DatabaseName, Columns, and OriginalSql'
@@ -35,6 +34,7 @@ class GlueView extends GlueTable {
       { comment: 'Presto View', presto_view: 'true' },
       Parameters
     );
+    SqlVariables = Object.assign({ DatabaseName }, SqlVariables);
 
     const columns = Columns.map((c) => ({
       name: c.Name,
@@ -46,7 +46,7 @@ class GlueView extends GlueTable {
         'Fn::Sub': [
           JSON.stringify({
             catalog: 'awsdatacatalog',
-            schema,
+            schema: '${DatabaseName}',
             originalSql,
             columns
           }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -4033,6 +4033,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+      "dev": true
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -6876,6 +6882,25 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-queue": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.3.0.tgz",
+      "integrity": "sha512-fg5dJlFpd5+3CgG3/0ogpVZUeJbjiyXFg0nu53hrOYsybqSiDyxyOpad0Rm6tAiGjgztAwkyvhlYHC53OiAJOA==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-node": "^6.0.1",
     "nyc": "^14.1.0",
     "opener": "^1.4.1",
+    "p-queue": "^6.3.0",
     "tape": "^4.6.0"
   },
   "dependencies": {

--- a/test/fixtures/shortcuts/glue-database-defaults.json
+++ b/test/fixtures/shortcuts/glue-database-defaults.json
@@ -13,8 +13,8 @@
         },
         "DatabaseInput": {
           "Name": "my_database",
-          "Description": { 
-            "Fn::Sub": "Created by the {$AWS::StackName} CloudFormation stack" 
+          "Description": {
+            "Fn::Sub": "Created by the {$AWS::StackName} CloudFormation stack"
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-json-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-json-table-defaults.json
@@ -31,7 +31,7 @@
             "SerdeInfo": {
               "SerializationLibrary": "org.openx.data.jsonserde.JsonSerDe"
             },
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-json-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-json-table-no-defaults.json
@@ -55,7 +55,7 @@
                 "SortOrder": 0
               }
             ],
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-orc-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-orc-table-defaults.json
@@ -31,7 +31,7 @@
                 "serialization.format": "1"
               }
             },
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-orc-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-orc-table-no-defaults.json
@@ -55,7 +55,7 @@
                 "SortOrder": 0
               }
             ],
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-table-defaults.json
@@ -23,7 +23,7 @@
             "Location": "",
             "NumberOfBuckets": 0,
             "SerdeInfo": {},
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-table-no-defaults.json
@@ -55,7 +55,7 @@
                 "SortOrder": 0
               }
             ],
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": true
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-view-defaults.json
+++ b/test/fixtures/shortcuts/glue-view-defaults.json
@@ -31,8 +31,10 @@
                 "view": {
                   "Fn::Base64": {
                     "Fn::Sub": [
-                      "{\"catalog\":\"awsdatacatalog\",\"schema\":\"my_database\",\"originalSql\":\"SELECT * FROM another.table\",\"columns\":[{\"name\":\"column\",\"type\":\"varchar\"}]}",
-                      {}
+                      "{\"catalog\":\"awsdatacatalog\",\"schema\":\"${DatabaseName}\",\"originalSql\":\"SELECT * FROM another.table\",\"columns\":[{\"name\":\"column\",\"type\":\"varchar\"}]}",
+                      {
+                        "DatabaseName": "my_database"
+                      }
                     ]
                   }
                 }
@@ -44,7 +46,7 @@
             "Location": "",
             "NumberOfBuckets": 0,
             "SerdeInfo": {},
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": false
           }
         }
       }

--- a/test/fixtures/shortcuts/glue-view-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-view-no-defaults.json
@@ -40,8 +40,9 @@
                 "view": {
                   "Fn::Base64": {
                     "Fn::Sub": [
-                      "{\"catalog\":\"awsdatacatalog\",\"schema\":\"my_database\",\"originalSql\":\"SELECT * FROM another.table\",\"columns\":[{\"name\":\"column\",\"type\":\"varchar\"}]}",
+                      "{\"catalog\":\"awsdatacatalog\",\"schema\":\"${DatabaseName}\",\"originalSql\":\"SELECT * FROM another.table\",\"columns\":[{\"name\":\"column\",\"type\":\"varchar\"}]}",
                       {
+                        "DatabaseName": "my_database",
                         "env": {
                           "Ref": "AWS::StackName"
                         }
@@ -73,7 +74,7 @@
                 "SortOrder": 0
               }
             ],
-            "StoredAsSubdirectories": true
+            "StoredAsSubDirectories": false
           }
         }
       }

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -11,8 +11,6 @@ const update = !!process.env.UPDATE;
 
 const noUndefined = (template) => JSON.parse(JSON.stringify(template));
 
-const schemaUrl = 'https://s3.amazonaws.com/cfn-resource-specifications-us-east-1-prod/schemas/2.15.0/all-spec.json';
-
 test('[shortcuts] fixture validation', async (assert) => {
   const queue = new Queue({ concurrency: 1 });
 

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -11,8 +11,10 @@ const update = !!process.env.UPDATE;
 
 const noUndefined = (template) => JSON.parse(JSON.stringify(template));
 
+const schemaUrl = 'https://s3.amazonaws.com/cfn-resource-specifications-us-east-1-prod/schemas/2.15.0/all-spec.json';
+
 test('[shortcuts] fixture validation', async (assert) => {
-  const queue = new Queue({ concurrency: 2 });
+  const queue = new Queue({ concurrency: 1 });
 
   const validations = fs
     .readdirSync(path.join(__dirname, 'fixtures', 'shortcuts'))


### PR DESCRIPTION
- The GlueTable shortcut had a `directories` where it needed to be `Directories`.
- The GlueView needs to be smarter about how it handles the `schema` (database name) that it puts into the presto view. This allows the provided value for DatabaseName to be a `cf.ref()`.
- Slows down fixture validation during tests, fixes #90 