### PR TITLE
link to subclassed Glue Table classes in docs

### DIFF
--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -544,6 +544,8 @@ module.exports = cf.merge(myTemplate, db);
 
 Create a Glue Table.
 
+Versions of this shortcut preconfigured for [line-delimited JSON][39] or [ORC][41] backed tables are available.
+
 ### Parameters
 
 -   `options` **[Object][57]** Options.

--- a/lib/shortcuts/glue-table.js
+++ b/lib/shortcuts/glue-table.js
@@ -3,6 +3,8 @@
 /**
  * Create a Glue Table.
  *
+ * Versions of this shortcut preconfigured for [line-delimited JSON](#gluejsontable) or [ORC](#glueorctable) backed tables are available.
+ *
  * @param {Object} options - Options.
  * @param {String} options.LogicalName - The logical name of the Glue Table within the CloudFormation template.
  * @param {String} options.Name - The name of the table. See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-table-tableinput.html#cfn-glue-table-tableinput-name).

--- a/local.dic
+++ b/local.dic
@@ -21,4 +21,5 @@ ServiceRole
 SNS
 SQS
 StreamLambda
+preconfigured
 webhooks


### PR DESCRIPTION
The GlueJSONTable and GlueORCTable shortcuts indicate that they are extended from the `GlueTable` class, but I want to make it clear that we provide these two shortcuts with defaults filled in for datasets which use those file formats. I don't think there's a way to do this automatically with the documentation module.