### PR TITLE
Pass Conditions through to Lambda shortcut roles

### DIFF
--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -226,6 +226,7 @@ class Lambda {
       const serviceRole = new ServiceRole({
         LogicalName: `${LogicalName}Role`,
         Service: 'lambda',
+        Condition,
         Statement
       });
       this.Resources[`${LogicalName}`].Properties.Role = { 'Fn::GetAtt': [`${LogicalName}Role`, 'Arn'] };

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -145,6 +145,7 @@
     },
     "MyLambdaRole": {
       "Type": "AWS::IAM::Role",
+      "Condition": "Always",
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [


### PR DESCRIPTION
Fixes #118 by passing the Condition along to the created ServiceRole.