### PR TITLE
Add top-level Rules support to merge

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const intrinsic = require('./lib/intrinsic');
 const conditions = require('./lib/conditions');
+const rules = require('./lib/rules');
 const pseudo = require('./lib/pseudo');
 const build = require('./lib/build');
 const validate = require('./lib/validate');
@@ -27,6 +28,10 @@ Object.keys(intrinsic).forEach((key) => {
 
 Object.keys(conditions).forEach((key) => {
   cloudfriend[key] = conditions[key];
+});
+
+Object.keys(rules).forEach((key) => {
+  cloudfriend[key] = rules[key];
 });
 
 Object.keys(pseudo).forEach((key) => {

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -11,8 +11,8 @@ const assert = require('assert');
  * @name merge
  * @param {...object} template - a CloudFormation template to merge with
  * @returns {object} a CloudFormation template including all the Metadata,
- * Parameters, Mappings, Conditions, Resources, and Outputs from the input
- * templates
+ * Parameters, Rules, Mappings, Conditions, Resources, and Outputs from the
+ * input templates
  * @throws errors when there is overlap in logical resource names between
  * templates
  */
@@ -23,6 +23,7 @@ module.exports = function() {
     AWSTemplateFormatVersion: '2010-09-09',
     Metadata: {},
     Parameters: {},
+    Rules: {},
     Mappings: {},
     Conditions: {},
     Resources: {},
@@ -34,6 +35,7 @@ module.exports = function() {
   const names = {
     Metadata: new Set(),
     Parameters: new Set(),
+    Rules: new Set(),
     Mappings: new Set(),
     Conditions: new Set(),
     Resources: new Set(),
@@ -60,6 +62,16 @@ module.exports = function() {
 
       template.Parameters[key] = arg.Parameters[key];
       names.Parameters.add(key);
+    });
+
+    if (arg.Rules) Object.keys(arg.Rules).forEach((key) => {
+      if (names.Rules.has(key)) {
+        try { assert.deepEqual(template.Rules[key], arg.Rules[key]); }
+        catch (err) { throw new Error('Rules name used more than once: ' + key); }
+      }
+
+      template.Rules[key] = arg.Rules[key];
+      names.Rules.add(key);
     });
 
     if (arg.Mappings) Object.keys(arg.Mappings).forEach((key) => {

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const rules = module.exports = {};
+
+/**
+ * [The rule function
+ * Fn::Contains](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-contains)
+ * returns true if a specified string matches at least one value in a list of
+ * strings.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name contains
+ * @param {array} strings
+ * @param {string} s
+ */
+rules.contains = (strings, s) => {
+  return { 'Fn::Contains': [strings, s] };
+};
+
+/**
+ * [The rule function
+ * Fn::EachMemberEquals](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-eachmemberequals)
+ * returns true if a specified string matches all values in a list.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name eachMemberEquals
+ * @param {array} strings
+ * @param {string} s
+ */
+rules.eachMemberEquals = (strings, s) => {
+  return { 'Fn::EachMemberEquals': [strings, s] };
+};
+
+/**
+ * [The rule function
+ * Fn::EachMemberIn](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-eachmemberin)
+ * returns true if each member in a list of strings matches at least one value
+ * in a second list of strings.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name eachMemberIn
+ * @param {array} stringsToCheck
+ * @param {array} stringsToMatch
+ */
+rules.eachMemberIn = (stringsToCheck, stringsToMatch) => {
+  return { 'Fn::EachMemberIn': [stringsToCheck, stringsToMatch] };
+};
+
+/**
+ * [The rule function Fn::RefAll](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-refall) returns all values for a specified parameter type.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name refAll
+ * @param {string} parameterType An AWS-specific parameter type, such as AWS::EC2::SecurityGroup::Id or AWS::EC2::VPC::Id.
+ */
+rules.refAll = (parameterType) => {
+  return { 'Fn::RefAll': parameterType };
+};
+
+/**
+ * [The rule function Fn::ValueOf](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-valueof) returns an attribute value or list of values for a specific parameter and attribute.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name valueOf
+ * @param {string} parameterLogicalId The name of a parameter for which you want to retrieve attribute values. The parameter must be declared in the Parameters section of the template.
+ * @param {*} attribute The name of an attribute from which you want to retrieve a value. For more information about attributes, see [Supported Attributes](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#rules-parameter-attributes).
+ */
+rules.valueOf = (parameterLogicalId, attribute) => {
+  return { 'Fn::ValueOf': [parameterLogicalId, attribute] };
+};
+
+/**
+ * [The rule function Fn::ValueOfAll](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-valueofall) returns a list of all attribute values for a given parameter type and attribute.
+ *
+ * @static
+ * @memberof cloudfriend
+ * @name valueOfAll
+ * @param {string} parameterType An AWS-specific parameter type, such as AWS::EC2::SecurityGroup::Id or AWS::EC2::VPC::Id.
+ * @param {string} attribute The name of an attribute from which you want to retrieve a value. For more information about attributes, see [Supported Attributes](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#rules-parameter-attributes).
+ */
+rules.valueOfAll = (parameterType, attribute) => {
+  return { 'Fn::ValueOfAll': [parameterType, attribute] };
+};

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,13 @@ sub(str, variables) | [Fn::Sub](http://docs.aws.amazon.com/AWSCloudFormation/lat
 importValue(sharedValue) | [Fn::ImportValue](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html),
 arn(service, suffix) | [Fn::Sub](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-sub.html) designed for an ARN
 transform(name, parameters) | [Fn::Transform](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-transform.html)
+contains(strings, s) | [Fn::Contains](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-contains)
+eachMemberEquals(strings, s) | [Fn::EachMemberEquals](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-eachmemberequals)
+eachMemberIn(stringsToCheck, stringsToMatch) | [Fn::EachMemberIn](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-eachmemberin)
+refAll(parameterType) | [Fn::RefAll](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-refall)
+valueOf(parameterLogicalId, attribute) | [Fn::ValueOf](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-valueof)
+valueOfAll(parameterType, attribute) | [Fn::ValueOfAll](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html#fn-valueofall)
+
 
 ## Pseudo parameters
 

--- a/test/fixtures/shortcuts/cross-account-role-defaults.json
+++ b/test/fixtures/shortcuts/cross-account-role-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/cross-account-role-no-defaults.json
+++ b/test/fixtures/shortcuts/cross-account-role-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/event-lambda-defaults.json
+++ b/test/fixtures/shortcuts/event-lambda-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/event-lambda-full.json
+++ b/test/fixtures/shortcuts/event-lambda-full.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/firehose-defaults.json
+++ b/test/fixtures/shortcuts/firehose-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/firehose-with-stream.json
+++ b/test/fixtures/shortcuts/firehose-with-stream.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-database-defaults.json
+++ b/test/fixtures/shortcuts/glue-database-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-database-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-database-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-json-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-json-table-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-json-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-json-table-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-orc-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-orc-table-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-orc-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-orc-table-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-parquet-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-parquet-table-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-parquet-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-parquet-table-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-table-defaults.json
+++ b/test/fixtures/shortcuts/glue-table-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-table-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-table-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/glue-view-defaults.json
+++ b/test/fixtures/shortcuts/glue-view-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/glue-view-no-defaults.json
+++ b/test/fixtures/shortcuts/glue-view-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/hookshot-github-secret-ref.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-ref.json
@@ -6,6 +6,7 @@
       "Type": "String"
     }
   },
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -27,7 +28,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -46,7 +47,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-github-secret-string.json
+++ b/test/fixtures/shortcuts/hookshot-github-secret-string.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-github.json
+++ b/test/fixtures/shortcuts/hookshot-github.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-access-log-format.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -51,7 +52,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-alarms.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-enhanced-logging.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-full-blown-logging.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough-logging.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough-logging.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/hookshot-passthrough.json
+++ b/test/fixtures/shortcuts/hookshot-passthrough.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {
@@ -23,7 +24,7 @@
       "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "PassDeployment636bae51"
+          "Ref": "PassDeployment15ce21d4"
         },
         "StageName": "hookshot",
         "RestApiId": {
@@ -42,7 +43,7 @@
         ]
       }
     },
-    "PassDeployment636bae51": {
+    "PassDeployment15ce21d4": {
       "Type": "AWS::ApiGateway::Deployment",
       "DependsOn": "PassMethod",
       "Properties": {

--- a/test/fixtures/shortcuts/lambda-defaults.json
+++ b/test/fixtures/shortcuts/lambda-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/lambda-provided-role.json
+++ b/test/fixtures/shortcuts/lambda-provided-role.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/lambda-zipfile.json
+++ b/test/fixtures/shortcuts/lambda-zipfile.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/log-subscription-lambda-defaults.json
+++ b/test/fixtures/shortcuts/log-subscription-lambda-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/log-subscription-lambda-no-defaults.json
+++ b/test/fixtures/shortcuts/log-subscription-lambda-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-defaults.json
+++ b/test/fixtures/shortcuts/queue-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-external-topic-ref.json
+++ b/test/fixtures/shortcuts/queue-external-topic-ref.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-external-topic.json
+++ b/test/fixtures/shortcuts/queue-external-topic.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-fifo-queuename.json
+++ b/test/fixtures/shortcuts/queue-fifo-queuename.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-fifo.json
+++ b/test/fixtures/shortcuts/queue-fifo.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-full.json
+++ b/test/fixtures/shortcuts/queue-full.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/queue-lambda-zero.json
+++ b/test/fixtures/shortcuts/queue-lambda-zero.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/queue-lambda.json
+++ b/test/fixtures/shortcuts/queue-lambda.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/role-defaults.json
+++ b/test/fixtures/shortcuts/role-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/role-no-defaults.json
+++ b/test/fixtures/shortcuts/role-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/scheduled-lambda-defaults.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/scheduled-lambda-full.json
+++ b/test/fixtures/shortcuts/scheduled-lambda-full.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/service-role-defaults.json
+++ b/test/fixtures/shortcuts/service-role-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/service-role-no-defaults.json
+++ b/test/fixtures/shortcuts/service-role-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {
     "Always": {

--- a/test/fixtures/shortcuts/service-role-no-url-suffix.json
+++ b/test/fixtures/shortcuts/service-role-no-url-suffix.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/service-role-url-suffix-with-replacement.json
+++ b/test/fixtures/shortcuts/service-role-url-suffix-with-replacement.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/service-role-url-suffix.json
+++ b/test/fixtures/shortcuts/service-role-url-suffix.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/stream-lambda-defaults.json
+++ b/test/fixtures/shortcuts/stream-lambda-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/fixtures/shortcuts/stream-lambda-no-defaults.json
+++ b/test/fixtures/shortcuts/stream-lambda-no-defaults.json
@@ -2,6 +2,7 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Metadata": {},
   "Parameters": {},
+  "Rules": {},
   "Mappings": {},
   "Conditions": {},
   "Resources": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -109,6 +109,7 @@ test('merge', (assert) => {
   const a = {
     Metadata: { Instances: { Description: 'Information about the instances' } },
     Parameters: { InstanceCount: { Type: 'Number' } },
+    Rules: { WeAreOutOfBacon: { Assertions: [{ Assert: cloudfriend.not('WouldYouLikeBaconWithThat') }] } },
     Mappings: { Region: { 'us-east-1': { AMI: 'ami-123456' } } },
     Conditions: { WouldYouLikeBaconWithThat: cloudfriend.equals(cloudfriend.ref('InstanceCount'), 999) },
     Transform: ['TransformB'],
@@ -119,6 +120,7 @@ test('merge', (assert) => {
   let b = {
     Metadata: { Databases: { Description: 'Information about the databases' } },
     Parameters: { DatabasePrefix: { Type: 'String' } },
+    Rules: { YouMustHaveBacon: { Assertions: [{ Assert: cloudfriend.and([cloudfriend.not('WouldYouLikeBaconWithThat'), 'TooMuch']) }] } },
     Mappings: { Prefix: { eggs: { Name: 'bananas' } } },
     Conditions: { TooMuch: cloudfriend.equals(cloudfriend.ref('DatabasePrefix'), 'bacon') },
     Transform: ['TransformA'],
@@ -140,6 +142,10 @@ test('merge', (assert) => {
       InstanceCount: { Type: 'Number' },
       DatabasePrefix: { Type: 'String' },
       NoConsequence: { Type: 'String' }
+    },
+    Rules: {
+      WeAreOutOfBacon: { Assertions: [{ Assert: cloudfriend.not('WouldYouLikeBaconWithThat') }] },
+      YouMustHaveBacon: { Assertions: [{ Assert: cloudfriend.and([cloudfriend.not('WouldYouLikeBaconWithThat'), 'TooMuch']) }] }
     },
     Mappings: {
       Region: { 'us-east-1': { AMI: 'ami-123456' } },
@@ -170,6 +176,7 @@ test('merge', (assert) => {
       AWSTemplateFormatVersion: '2010-09-09',
       Metadata: {},
       Parameters: { InstanceCount: { Type: 'Number' } },
+      Rules: {},
       Mappings: {},
       Conditions: {},
       Transform: ['foo', 'baz', 'bar'],
@@ -202,6 +209,16 @@ test('merge', (assert) => {
     b = { Parameters: { InstanceCount: { Type: 'Number' } } };
     cloudfriend.merge(a, b);
   }, 'allows identical .Parameters overlap');
+
+  assert.throws(() => {
+    b = { Rules: { WeAreOutOfBacon: { Assertions: [{ Assert: cloudfriend.not('WouldYouLikeBaconWithThat'), AssertDescription: 'Different' }] } } };
+    cloudfriend.merge(a, b);
+  }, /Rules name used more than once: WeAreOutOfBacon/, 'throws in .Rules overlap');
+
+  assert.doesNotThrow(() => {
+    b = { Rules: { WeAreOutOfBacon: { Assertions: [{ Assert: cloudfriend.not('WouldYouLikeBaconWithThat') }] } } };
+    cloudfriend.merge(a, b);
+  }, 'allows identical .Rules overlap');
 
   assert.throws(() => {
     b = { Mappings: { Region: { 'us-east-1': { AMI: 'ami-123456' }, 'us-east-4': { AMI: 'ami-123456' } } } };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,6 +41,16 @@ test('conditions', (assert) => {
   assert.end();
 });
 
+test('rules', (assert) => {
+  assert.deepEqual(cloudfriend.contains(['a', 'b'], 'a'), { 'Fn::Contains': [['a', 'b'], 'a'] });
+  assert.deepEqual(cloudfriend.eachMemberEquals(['a', 'a'], 'a'), { 'Fn::EachMemberEquals': [['a', 'a'], 'a'] });
+  assert.deepEqual(cloudfriend.eachMemberIn(['a', 'b'], ['a', 'b', 'c']), { 'Fn::EachMemberIn': [['a', 'b'], ['a', 'b', 'c']] });
+  assert.deepEqual(cloudfriend.refAll('a'), { 'Fn::RefAll': 'a' });
+  assert.deepEqual(cloudfriend.valueOf('a', 'b'), { 'Fn::ValueOf': ['a', 'b'] });
+  assert.deepEqual(cloudfriend.valueOfAll('a', 'b'), { 'Fn::ValueOfAll': ['a', 'b'] });
+  assert.end();
+});
+
 test('pseudo', (assert) => {
   assert.deepEqual(cloudfriend.accountId, { Ref: 'AWS::AccountId' }, 'account');
   assert.deepEqual(cloudfriend.notificationArns, { Ref: 'AWS::NotificationARNs' }, 'notificationArns');


### PR DESCRIPTION
This PR prevents cf.merge from removing [`Rules`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/rules-section-structure.html) from the top-level template, allowing users to add complex validations.

`Rules` is similar to other top-level sections, in that it's an object with keys that are unique and values that are objects.  Each rule has:
- `Assertions`, an array of objects with `AssertDescription` (a string) and `Assert` (a function) keys.
- An (optional) `RuleCondition`, a function

`Assert` and `RuleCondition` accept [rule-specific intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-rules.html), which partly overlap with general CFN intrinsic functions.  ~This PR doesn't add those, for clarity and because that will take longer -- but I'm preparing a PR for that, too.~  I added these to fa26729.

cc/ @mapbox/release-engineering for review, please