### PR TITLE
More complete glue->presto translation for views

### DIFF
--- a/lib/shortcuts/glue-presto-view.js
+++ b/lib/shortcuts/glue-presto-view.js
@@ -36,7 +36,17 @@ class GluePrestoView extends GlueTable {
 
     const columns = Columns.map((c) => ({
       name: c.Name,
-      type: c.Type.replace(/string/g, 'varchar')
+      type: c.Type
+        .replace(/:string/g, ':varchar')
+        .replace(/^string/g, 'varchar')
+        .replace(/:int/g, ':integer')
+        .replace(/^int/g, 'integer')
+        .replace(/:float/g, ':real')
+        .replace(/^float/g, 'real')
+        .replace(/struct/g, 'row')
+        .replace(/</g, '(')
+        .replace(/>/g, ')')
+        .replace(/:/g, ' ')
     }));
 
     const view = {


### PR DESCRIPTION
This adds a more complete set of translations between Glue-syntax for field types --> Presto-syntax in the GluePrestoView shortcut.

cc @Ramshackle-Jamathon thanks for the tips.