### PR TITLE
Update dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.1.1
+
+- Dependency updates to avoid security vulnerabilities (minimist).
+
 ## v5.1.0
 - Lambda shortcuts now support custom Docker images.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7532,9 +7532,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.829.0",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "redent": "^2.0.0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This PR updates vulnerable dependencies.

Updated dependencies:

* `minimist`: `v1.2.5` -> `v1.2.6`

Changes in the updated dependencies:

* [`minimist`](https://github.com/substack/minimist/compare/1.2.5...1.2.6): Fixed a security vulnerability, no breaking changes detected.