### PR TITLE
Rename the policy name

### DIFF
--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -198,7 +198,7 @@ class Lambda {
         Condition,
         DependsOn: (RoleArn) ? undefined : `${LogicalName}Role`,
         Properties: {
-          PolicyName: 'lambda-log-access',
+          PolicyName: `lambda-log-access-${LogicalName}`,
           Roles: [roleName],
           PolicyDocument: {
             Version: '2012-10-17',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cloudfriend",
-      "version": "7.1.0",
+      "version": "7.1.1",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1425.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
When a stack defines multiple Lambdas, and these Lambdas use the RoleArn parameter to specify the Lambda’s role property, the policy will be duplicated to add to the same role.

This PR try to fix this issue.