### PR TITLE
Add support for default values in FindInMap

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.1.1
+
+- Add support for supplying default values to `Fn::FindInMap`. As per the [official documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap-enhancements.html#intrinsic-function-reference-findinmap-enhancements-supported-functions), you can now provide either a string or an intrinsic function as the default value for `Fn::FindInMap`.
+
 ## 7.1.0
 
 - Add support for `Fn::ForEach`. With `Fn::ForEach`, you can replicate parts of your templates with minimal lines of code, as per the [official AWS announcement](https://aws.amazon.com/about-aws/whats-new/2023/07/accelerate-cloudformation-authoring-experience-looping-function/) and [the documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-foreach.html).

--- a/lib/intrinsic.js
+++ b/lib/intrinsic.js
@@ -48,9 +48,13 @@ intrinsic.cidr = (ipBlock, count, cidrBits) => {
  * key-value pairs.
  * @param {string} attr - The second-level key name, which is set to one of the
  * keys from the list assigned to key.
+ * @param {string?} defaultValue - The value that Fn::FindInMap will resolve to if the TopLevelKey and/or SecondLevelKey can not be found from the MapName map. This field is optional.
  * @returns The value that is assigned to SecondLevelKey.
  */
-intrinsic.findInMap = (mapping, key, attr) => {
+intrinsic.findInMap = (mapping, key, attr, defaultValue) => {
+  if (defaultValue) {
+    return { 'Fn::FindInMap': [mapping, key, attr, { 'DefaultValue': defaultValue }] };
+  }
   return { 'Fn::FindInMap': [mapping, key, attr] };
 };
 
@@ -285,8 +289,10 @@ intrinsic.arn = (service, suffix) => {
  * @returns the processed template snippet to be included in the processed stack template.
  */
 intrinsic.transform = (name, parameters) => {
-  return { 'Fn::Transform': {
-    Name: name,
-    Parameters: parameters
-  } };
+  return {
+    'Fn::Transform': {
+      Name: name,
+      Parameters: parameters
+    }
+  };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "7.1.0",
+  "version": "7.1.1-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/cloudfriend",
-      "version": "7.1.0",
+      "version": "7.1.1-rc.0",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1425.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "7.1.0",
+  "version": "7.1.1-rc.0",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ CloudFriend | CloudFormation
 --- | ---
 base64(value) | [Fn::Base64](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-base64.html)
 cidr(ipBlock, count, cidrBits) | [Fn::Cidr](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-cidr.html)
-findInMap(mapping, key, attr) | [Fn::FindInMap](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html)
+findInMap(mapping, key, attr, defaultValue) | [Fn::FindInMap](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap.html)
 forEach(uniqueLoopName, identifier, collection, outputKeyPrefix, outputValue) | [Fn::ForEach](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-foreach.html)
 getAtt(obj, key) | [Fn::GetAtt](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html)
 getAzs(region) | [Fn::GetAZs](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getavailabilityzones.html)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,7 +10,8 @@ const fixtures = path.resolve(__dirname, 'fixtures');
 test('intrinsic functions', (assert) => {
   assert.deepEqual(cloudfriend.base64('secret'), { 'Fn::Base64': 'secret' }, 'base64');
   assert.deepEqual(cloudfriend.cidr('ipBlock', 1, 2), { 'Fn::Cidr': ['ipBlock', 1, 2] }, 'cidr');
-  assert.deepEqual(cloudfriend.findInMap('mapping', 'key', 'value'), { 'Fn::FindInMap': ['mapping', 'key', 'value'] }, 'lookup');
+  assert.deepEqual(cloudfriend.findInMap('mapping', 'key', 'value'), { 'Fn::FindInMap': ['mapping', 'key', 'value'] }, 'findInMap - No Default supplied');
+  assert.deepEqual(cloudfriend.findInMap('mapping', 'key', 'value', 'default_value'), { 'Fn::FindInMap': ['mapping', 'key', 'value', { DefaultValue: 'default_value' }] }, 'findInMap - Default supplied');
   assert.deepEqual(
     cloudfriend.forEach('somethings', 'topic', ['abra', 'cadabra'], 'magic', {
       Type: 'AWS::SNS::Topic',


### PR DESCRIPTION
As per the [official documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-findinmap-enhancements.html#intrinsic-function-reference-findinmap-enhancements-supported-functions),
you can now provide either a string or an intrinsic function as the default value for `Fn::FindInMap`.
