### PR TITLE
add option for lambda log retention period

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.2.0
+
+- Add `LogRetentionInDays` option to Lambda shortcuts
+
 ## 8.1.0
 
 - Allow `FilterCriteria` property to be defined for Stream Lambda shortcuts
@@ -25,7 +29,7 @@ When you make this update, you will no longer see a trigger on your scheduled la
 ## 7.1.0
 
 - Add support for `Fn::ForEach`. With `Fn::ForEach`, you can replicate parts of your templates with minimal lines of code, as per the [official AWS announcement](https://aws.amazon.com/about-aws/whats-new/2023/07/accelerate-cloudformation-authoring-experience-looping-function/) and [the documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-foreach.html).
-  
+
 ## v7.0.1
 
 - Fixes `hookshot.Passthrough` and `hookshot.Github` shortcuts where inline code lambdas were using AWS SDK v2 while the lambda default runtime is `nodejs18.x`, by switching to AWS SDK v3.
@@ -47,23 +51,29 @@ When you make this update, you will no longer see a trigger on your scheduled la
 - Dependency updates to avoid security vulnerabilities (minimist).
 
 ## v5.1.0
+
 - Lambda shortcuts now support custom Docker images.
 
 ## v5.0.2
+
 - Fixes handling custom access log formats in hookshot shortcuts.
 
 ## v5.0.1
+
 - Improves data type mappings between Glue and Presto when using the `GluePrestoView` shortcut.
 
 ## v5.0.0
+
 - The Lambda shortcuts now use `nodejs12.x` as the default runtime.
 - There is no longer any constraint on the useable Lambda runtimes.
 
 ## v4.6.0
+
 - Adds top-level `Rules` section support to `cf.merge`. Each key in `Rules` must have a unique name.
 - Adds rule-specific intrinsic functions: `contains`, `eachMemberEquals`, `eachMemberIn`, `refAll`, `valueOf`, `valueOfAll`
 
 ## v4.5.1
+
 - Fixes a bug present in v4.4.0 and v4.5.0 where Lambda shortcuts' Conditions were not passed to the generated IAM Roles.
 
 ## v4.5.0
@@ -174,7 +184,7 @@ When you make this update, you will no longer see a trigger on your scheduled la
 ## v2.8.0
 
 - Allows Hookshot callers to bring their own webhook secret. This is used for
-signature-verification in the `.Github()` case.
+  signature-verification in the `.Github()` case.
 
 ## v2.7.0
 

--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -422,6 +422,7 @@ Log Group, a Role, an Alarm on function errors, and the Lambda Function itself.
 | [options.EvaluateLowSampleCountPercentile] | <code>String</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-evaluatelowsamplecountpercentile). |
 | [options.ExtendedStatistic] | <code>String</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-extendedstatistic)] |
 | [options.OKActions] | <code>Array.&lt;String&gt;</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-okactions). |
+| [options.LogRetentionInDays] | <code>Number</code> | <code>14</code> | How long to retain CloudWatch logs for this Lambda function. See [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html) for allowed values. |
 
 **Example**  
 ```js

--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -46,6 +46,7 @@ const ServiceRole = require('./service-role');
  * @param {String} [options.EvaluateLowSampleCountPercentile=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-evaluatelowsamplecountpercentile).
  * @param {String} [options.ExtendedStatistic=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-extendedstatistic)]
  * @param {Array<String>} [options.OKActions=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-okactions).
+ * @param {Number} [options.LogRetentionInDays=14] - How long to retain CloudWatch logs for this Lambda function. See [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html) for allowed values.
  *
  * @example
  * const cf = require('@mapbox/cloudfriend');
@@ -104,7 +105,8 @@ class Lambda {
       TreatMissingData = 'notBreaching',
       EvaluateLowSampleCountPercentile,
       ExtendedStatistic,
-      OKActions
+      OKActions,
+      LogRetentionInDays = 14
     } = options;
 
     if (options.EvaluationPeriods < Math.ceil(Timeout / Period))
@@ -138,7 +140,7 @@ class Lambda {
           LogGroupName: {
             'Fn::Sub': ['/aws/lambda/${name}', { name: FunctionName }]
           },
-          RetentionInDays: 14
+          RetentionInDays: LogRetentionInDays
         }
       },
 

--- a/test/fixtures/shortcuts/lambda-full.json
+++ b/test/fixtures/shortcuts/lambda-full.json
@@ -6,10 +6,7 @@
   "Mappings": {},
   "Conditions": {
     "Always": {
-      "Fn::Equals": [
-        "1",
-        "1"
-      ]
+      "Fn::Equals": ["1", "1"]
     }
   },
   "Resources": {
@@ -28,7 +25,7 @@
             }
           ]
         },
-        "RetentionInDays": 14
+        "RetentionInDays": 30
       }
     },
     "MyLambda": {
@@ -52,9 +49,7 @@
         "FunctionName": "my-function",
         "Handler": "index.something",
         "KmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/fake",
-        "Layers": [
-          "arn:aws:fake:layer/abc"
-        ],
+        "Layers": ["arn:aws:fake:layer/abc"],
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 10,
         "Runtime": "nodejs18.x",
@@ -63,12 +58,8 @@
           "Mode": "Active"
         },
         "VpcConfig": {
-          "SecurityGroupIds": [
-            "sg-12345"
-          ],
-          "SubnetIds": [
-            "fake"
-          ]
+          "SecurityGroupIds": ["sg-12345"],
+          "SubnetIds": ["fake"]
         },
         "Tags": [
           {
@@ -77,10 +68,7 @@
           }
         ],
         "Role": {
-          "Fn::GetAtt": [
-            "MyLambdaRole",
-            "Arn"
-          ]
+          "Fn::GetAtt": ["MyLambdaRole", "Arn"]
         }
       }
     },
@@ -90,9 +78,7 @@
       "Properties": {
         "AlarmName": "my-alarm",
         "AlarmDescription": "some alarm",
-        "AlarmActions": [
-          "devnull@mapbox.com"
-        ],
+        "AlarmActions": ["devnull@mapbox.com"],
         "Period": 120,
         "EvaluationPeriods": 2,
         "DatapointsToAlarm": 1,
@@ -101,9 +87,7 @@
         "ComparisonOperator": "LessThanThreshold",
         "TreatMissingData": "breaching",
         "EvaluateLowSampleCountPercentile": "ignore",
-        "OKActions": [
-          "devnull@mapbox.com"
-        ],
+        "OKActions": ["devnull@mapbox.com"],
         "Namespace": "AWS/Lambda",
         "Dimensions": [
           {
@@ -134,10 +118,7 @@
               "Effect": "Allow",
               "Action": "logs:*",
               "Resource": {
-                "Fn::GetAtt": [
-                  "MyLambdaLogs",
-                  "Arn"
-                ]
+                "Fn::GetAtt": ["MyLambdaLogs", "Arn"]
               }
             }
           ]

--- a/test/shortcuts.test.js
+++ b/test/shortcuts.test.js
@@ -190,7 +190,8 @@ test('[shortcuts] lambda', (assert) => {
     TreatMissingData: 'breaching',
     EvaluateLowSampleCountPercentile: 'ignore',
     ExtendedStatistics: 'p100',
-    OKActions: ['devnull@mapbox.com']
+    OKActions: ['devnull@mapbox.com'],
+    LogRetentionInDays: 30
   });
 
   template = cf.merge(


### PR DESCRIPTION
Rather than having this be hard-coded to always be 14 days, let's make it an option that defaults to 14 days.