### PR TITLE
feat: support ImageConfig for Lambda

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.4.0
+
+- Support `ImageConfig` property for Lambda
+
 ## 8.3.0
 
 - Support a default value for cf.findInMap (Fn::FindInMap).

--- a/lib/shortcuts/api.md
+++ b/lib/shortcuts/api.md
@@ -391,6 +391,7 @@ Log Group, a Role, an Alarm on function errors, and the Lambda Function itself.
 | options | <code>Object</code> |  | Options. |
 | options.LogicalName | <code>String</code> |  | The logical name of the Lambda function within the CloudFormation template. This is used to construct the logical names of the other resources, as well as the Lambda function's name. |
 | options.Code | <code>Object</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html). |
+| [options.ImageConfig] | <code>Object</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig). |
 | [options.DeadLetterConfig] | <code>Object</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-deadletterconfig). |
 | [options.Description] | <code>String</code> | <code>&#x27;${logical name} in the ${stack name} stack&#x27;</code> | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description). |
 | [options.Environment] | <code>Object</code> |  | See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-environment). |

--- a/lib/shortcuts/lambda.js
+++ b/lib/shortcuts/lambda.js
@@ -12,6 +12,7 @@ const ServiceRole = require('./service-role');
  * within the CloudFormation template. This is used to construct the logical
  * names of the other resources, as well as the Lambda function's name.
  * @param {Object} options.Code - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html).
+ * @param {Object} [options.ImageConfig=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-imageconfig).
  * @param {Object} [options.DeadLetterConfig=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-deadletterconfig).
  * @param {String} [options.Description='${logical name} in the ${stack name} stack'] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-description).
  * @param {Object} [options.Environment=undefined] - See [AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-environment).
@@ -70,6 +71,7 @@ class Lambda {
     const {
       LogicalName,
       Code,
+      ImageConfig,
       DeadLetterConfig,
       Description = { 'Fn::Sub': `${LogicalName} in the \${AWS::StackName} stack` },
       Environment,
@@ -150,6 +152,7 @@ class Lambda {
         DependsOn,
         Properties: {
           Code,
+          ImageConfig,
           DeadLetterConfig,
           Description,
           Environment,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This change adds support for AWS Lambda property [ImageConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-imageconfig.html)

The change was tested as part of another project by locally editing the `CloudFriend` Node module:
![Screenshot 2025-05-20 at 13 03 49](https://github.com/user-attachments/assets/619ab68e-e404-4d64-b2f1-19c07a3058a9)

And after deployment it's visible in the lambda console (one of the three Lambdas as an example):
![Screenshot 2025-05-20 at 13 06 22](https://github.com/user-attachments/assets/f6613b13-de55-44f8-8fb6-7d0bf71be236)
