### PR TITLE
CLOUDPLAT-3217: add npm publish workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -6,5 +6,8 @@ on:
 jobs:
   npm-release:
     uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    permissions:
+      id-token: write
+      contents: write
     with:
       create-github-release: true

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,0 +1,10 @@
+name: NPM release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  npm-release:
+    uses: mapbox/gha-public/.github/workflows/workflow-npm-oidc-publish.yml@main
+    with:
+      create-github-release: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to cloudfriend
+
+## Development
+
+```bash
+npm ci
+npm test
+```
+
+## Releasing a new version
+
+Releases are published to npm via GitHub Actions
+
+### Steps
+
+1. **Bump the version** in `package.json` (follow [semver](https://semver.org))
+2. **Update `CHANGELOG.md`** with a summary of what changed
+3. **Open a PR**, get it reviewed and merged to `master`
+4. **Trigger the release** from the [Actions tab](../../actions/workflows/npm-release.yml):
+   - Select **NPM release** → **Run workflow** → run from `master`
+
+The workflow will publish to npm, and create a GitHub release with auto-generated notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,3 +20,5 @@ Releases are published to npm via GitHub Actions
    - Select **NPM release** → **Run workflow** → run from `master`
 
 The workflow will publish to npm, and create a GitHub release with auto-generated notes.
+
+> **Note:** Only Mapbox maintainers with write access to this repository can trigger the release workflow. External contributors can open and contribute to PRs, but releases are always cut by the owning team.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   ],
   "author": "Mapbox",
   "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  },
   "bugs": {
     "url": "https://github.com/mapbox/cloudfriend/issues"
   },


### PR DESCRIPTION
Jira: [CLOUDPLAT-3217](https://mapbox.atlassian.net/browse/CLOUDPLAT-3217)

## Changes

- **`.github/workflows/npm-release.yml`**: New `workflow_dispatch` workflow that publishes to npm and creates a GitHub release.
- **`package.json`**: Added `publishConfig: { access: "public" }` for the scoped package. Bumped version to `9.4.2`.
- **`CONTRIBUTING.md`**: Documents the release process — bump version, update CHANGELOG, merge PR, trigger workflow from Actions.

## Note

This PR is blocked on [mapbox/gha-public](https://github.com/mapbox/gha-public) being made public. The reusable workflow referenced in `npm-release.yml` will not be accessible to this repo until `gha-public` is a public repository.

[CLOUDPLAT-3217]: https://mapbox.atlassian.net/browse/CLOUDPLAT-3217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ