### PR TITLE
CLOUDPLAT-3162: disable run-tests in npm-release workflow

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -11,3 +11,4 @@ jobs:
       contents: write
     with:
       create-github-release: true
+      run-tests: false


### PR DESCRIPTION
## Summary

The `npm-release.yml` workflow was failing because `test/shortcuts.test.js` calls `cfn-lint` (a Python tool) which isn't installed in the reusable workflow's runner. The existing `test.yml` CI workflow handles this by installing Python and `cfn-lint` via `requirements.dev.txt` before running tests.

Since tests are already enforced on every PR merge via `test.yml`, there's no need to re-run them at publish time. Adding `run-tests: false` skips the test step in the publish workflow.

Ticket: https://mapbox.atlassian.net/browse/CLOUDPLAT-3162