### PR TITLE
CLOUDPLAT-3162: add npm-release environment gate (cloudfriend)

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    environment: npm-release
     with:
       create-github-release: true
       run-tests: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/cloudfriend",
-  "version": "9.4.2",
+  "version": "9.4.3",
   "description": "Helper functions for assembling CloudFormation templates in JavaScript",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Adding `environment: npm-release` to the npm release workflow.